### PR TITLE
Add Reepl - LinkedIn Content Creation skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ Thirty-five curated skill modules included in this repo, with access to **15,000
 
 | Skill | Install | What It Teaches |
 |-------|---------|------------------|
-| [Reepl - LinkedIn Content Creation](https://github.com/reepl-io/skills) | `npx skills add reepl-io/skills` | 18 tools for LinkedIn content management: drafts, publishing, scheduling, voice profiles, contacts, collections, templates, and AI image generation |
+| [Reepl - LinkedIn Content Creation](https://github.com/reepl-io/skills) | `npx skillkit@latest install reepl-io/skills` | 18 tools for LinkedIn content management: drafts, publishing, scheduling, voice profiles, contacts, collections, templates, and AI image generation |
 
 ### Installing Skills
 


### PR DESCRIPTION
Adds Reepl to the Community Skills section. Reepl is a Claude Code skill for LinkedIn content management with 18 MCP tools covering drafts, publishing, scheduling, voice profiles, contacts, collections, templates, and AI image generation.

- Website: https://reepl.io
- Install: `npx skills add reepl-io/skills`
- GitHub: https://github.com/reepl-io/skills

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated installation guidance to reflect current SkillKit marketplace workflows and broader install examples
  * Added a Community Skills subsection highlighting community-contributed tools and an example install command
* **Bug Fixes**
  * Note: Community Skills content was unintentionally duplicated in the README and may appear twice
<!-- end of auto-generated comment: release notes by coderabbit.ai -->