### PR TITLE
Update Skills section with agentskill.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ Reference an agent in your `CLAUDE.md`:
 
 ## Skills
 
-Thirty-five curated skill modules included in this repo, with access to **44,000+ additional skills** via [agentskill.sh](https://agentskill.sh) (use `/learn` to search and install with security scanning). Each included skill teaches Claude Code domain-specific patterns with code examples, anti-patterns, and checklists.
+Thirty-five curated skill modules included in this repo, with access to **48,000+ additional skills** via [agentskill.sh](https://agentskill.sh) (use `/learn` to search and install with security scanning). Each included skill teaches Claude Code domain-specific patterns with code examples, anti-patterns, and checklists.
 
 | Skill | Directory | What It Teaches |
 |-------|-----------|-----------------|


### PR DESCRIPTION
Updates the Skills section to link to [agentskill.sh](https://agentskill.sh) instead of the broken SkillKit link.

**What it provides:**
- 44k+ skills (vs the broken 15k link)
- Two-layer security scanning across 12 threat categories
- `/learn` installer for one-command installation

[Browse skills](https://agentskill.sh) | [Security dashboard](https://agentskill.sh/security)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Skills section to reflect an expanded library of 48,000+ available skills and replaced the external reference with agentskill.sh
  * Added guidance to use `/learn` to search for and install skills with integrated security scanning
<!-- end of auto-generated comment: release notes by coderabbit.ai -->