### PR TITLE
Add Related Projects section with claude-pipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -724,6 +724,14 @@ claude-code-toolkit/               796 files
 
 ---
 
+## Related Projects
+
+| Project | Description |
+|---------|-------------|
+| [claude-pipe](https://github.com/bluzir/claude-pipe) | Conventions for multi-step Claude Code pipelines. File-based YAML state, flat orchestration, data layer contracts, resume-from-failure. Complements this toolkit's orchestration agents with end-to-end pipeline patterns |
+
+---
+
 ## Contributing
 
 Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines.


### PR DESCRIPTION
Adding a Related Projects section with [claude-pipe](https://github.com/bluzir/claude-pipe).

**The toolkit's orchestration agents** (task-coordinator, workflow-director, multi-agent-coordinator) handle individual orchestration concerns well. claude-pipe provides the surrounding conventions for running whole pipelines end-to-end: file-based state tracking, data layer contracts between phases, resume-from-failure, and session isolation.

Figured a Related Projects section is the right place since it's an external framework that complements the toolkit rather than a plugin/agent that lives inside it. Happy to adjust placement if you'd prefer it elsewhere.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a "Related Projects" section to the README, highlighting recommended projects and resources for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->