### PR TITLE
Add pm-skills to community skill collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,14 @@ Thirty-five curated skill modules included in this repo, with access to **15,000
 | Data Engineering | `skills/data-engineering/` | ETL pipelines, Spark, star schema, data quality |
 | LLM Integration | `skills/llm-integration/` | Streaming, function calling, RAG, cost optimization |
 
+### Community Skill Collections
+
+External skill packages contributed by the community.
+
+| Collection | Skills | What It Covers |
+|------------|--------|----------------|
+| [pm-skills](https://github.com/product-on-purpose/pm-skills) | 24 | Product management across the Triple Diamond — discovery, definition, delivery, PRDs, roadmaps, stakeholder alignment |
+
 ### Installing Skills
 
 **Browse and install via SkillKit** (recommended):


### PR DESCRIPTION
## Summary

Adds [pm-skills](https://github.com/product-on-purpose/pm-skills) — a collection of **24 product-management skills** — to a new **Community Skill Collections** subsection under Skills.

- **What:** 24 plug-and-play PM agent skills covering the full Triple Diamond (discovery, definition, delivery), including PRDs, roadmaps, stakeholder alignment, and more
- **Format:** [agentskills.io specification](https://agentskills.io/specification), Apache-2.0 licensed
- **Why a new subsection?** The existing Skills table lists bundled skill modules with local directory paths. Community collections are external repos with multiple skills, so a separate table keeps the distinction clear while still being discoverable.

## Changes

- Added a `### Community Skill Collections` subsection between the skills table and the "Installing Skills" subsection
- Single table row for pm-skills with link, skill count, and description

## Checklist

- [x] Entry follows existing table formatting conventions
- [x] Link points to a public, actively maintained repository
- [x] No changes to existing content

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a "Community Skill Collections" section to provide visibility into external skill collections and their coverage.
  * Updated installation guidance with an npx-based command for simplified skill installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->