### PR TITLE
Add Companion Apps section with Poirot

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ curl -fsSL https://raw.githubusercontent.com/rohitg00/awesome-claude-code-toolki
 - [Contexts](#contexts) (5)
 - [Examples](#examples) (3)
 - [Setup](#setup)
+- [Companion Apps](#companion-apps)
 - [Contributing](#contributing)
 
 ---
@@ -728,6 +729,14 @@ claude-code-toolkit/               796 files
   examples/                        3 walkthrough examples
   setup/                           Interactive installer
 ```
+
+---
+
+## Companion Apps
+
+| Name | Description |
+|------|-------------|
+| [Poirot](https://github.com/LeonardoCardoso/Poirot) | A macOS app for browsing Claude Code sessions, viewing diffs, and re-running commands. Reads local transcripts, runs offline |
 
 ---
 


### PR DESCRIPTION
Added a "Companion Apps" section for apps that work alongside Claude Code. First entry is Poirot, a macOS app for browsing sessions, viewing diffs, and re-running commands from your local transcripts.

https://github.com/LeonardoCardoso/Poirot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Companion Apps section to the documentation, featuring a curated table of companion applications with descriptions to help users discover available tools and extensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->