### PR TITLE
Add LightCMS to plugins list

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ One hundred twenty-one production-ready plugins that extend Claude Code with dom
 | [k8s-helper](plugins/k8s-helper/) | Generate Kubernetes manifests and debug pod issues with kubectl |
 | [license-checker](plugins/license-checker/) | License compliance checking and NOTICE file generation |
 | [lighthouse-runner](plugins/lighthouse-runner/) | Run Lighthouse audits and fix performance issues |
+| [lightcms](https://github.com/jonradoff/lightcms) | AI-native CMS with 41 MCP tools for managing websites through natural language — pages, templates, assets, themes, collections, redirects, and more with full content versioning |
 | [linear-helper](plugins/linear-helper/) | Linear issue tracking integration and workflow management |
 | [load-tester](plugins/load-tester/) | Load and stress testing for APIs and web services |
 | [memory-profiler](plugins/memory-profiler/) | Memory leak detection and heap analysis |


### PR DESCRIPTION
## Summary

- Adds [LightCMS](https://github.com/jonradoff/lightcms) to the plugins table in alphabetical order (between `lighthouse-runner` and `linear-helper`)
- LightCMS is an AI-native CMS with 41 MCP tools for managing websites through natural language — pages, templates, assets, themes, collections, redirects, and more with full content versioning

## Details

LightCMS provides a comprehensive set of MCP tools that let Claude Code (and other MCP clients) manage website content directly through natural language. It covers the full CMS lifecycle: creating and editing pages, managing templates, uploading assets, configuring themes, handling collections, setting up redirects, and tracking content versions.

Repository: https://github.com/jonradoff/lightcms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new plugin entry to the documentation with description and reference link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->