### PR TITLE
Add Silicon Friendly to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,7 @@ Thirty-five curated skill modules included in this repo, with access to **15,000
 | Skill | Install | What It Teaches |
 |-------|---------|------------------|
 | [Reepl - LinkedIn Content Creation](https://github.com/reepl-io/skills) | `npx skillkit@latest install reepl-io/skills` | 18 tools for LinkedIn content management: drafts, publishing, scheduling, voice profiles, contacts, collections, templates, and AI image generation |
+| [Silicon Friendly](https://github.com/unlikefraction/silicon-friendly) | MCP server: `https://siliconfriendly.com/mcp` | AI-agent-friendliness checker: rates websites on 30 criteria across 5 levels (L1-L5), finds optimal agent entry points (llms.txt, APIs, discovery endpoints) for integration planning |
 
 ### Installing Skills
 


### PR DESCRIPTION
## Summary

Adds [Silicon Friendly](https://siliconfriendly.com) to the **Community Skills** section.

Silicon Friendly is an AI-agent-friendliness directory and MCP server that:
- Rates websites on **30 binary criteria** across **5 levels** (L1-L5): Readability, Discoverability, API Interaction, Autonomous Action, and Persistent Agency
- Helps developers find the **optimal agent entry point** (llms.txt, API docs, agent discovery endpoints) for any website
- Available as an MCP server at `https://siliconfriendly.com/mcp`
- Publishes a skill.md at `https://siliconfriendly.com/.well-known/skill.md`

### Use case
Before building agent integrations with third-party services, use Silicon Friendly to check the target website's agent-friendliness level and find the best programmatic entry point.

- GitHub: https://github.com/unlikefraction/silicon-friendly
- Website: https://siliconfriendly.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Community Skills documentation to include Silicon Friendly with project link and MCP server configuration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->