### PR TITLE
Add OpenPaw (pawmode) to Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,7 @@ Thirty-five curated skill modules included in this repo, with access to **15,000
 
 | Skill | Install | What It Teaches |
 |-------|---------|------------------|
+| [OpenPaw](https://github.com/daxaur/openpaw) | `npx pawmode` | 38 built-in skills turning Claude Code into a personal assistant: Telegram, Discord, Obsidian memory, daily briefings, MCP server setup, and more. No daemon, no cloud, MIT licensed |
 | [Reepl - LinkedIn Content Creation](https://github.com/reepl-io/skills) | `npx skillkit@latest install reepl-io/skills` | 18 tools for LinkedIn content management: drafts, publishing, scheduling, voice profiles, contacts, collections, templates, and AI image generation |
 
 ### Installing Skills


### PR DESCRIPTION
## Summary
- Adds [OpenPaw](https://github.com/daxaur/openpaw) to the list
- Open-source CLI tool (`npx pawmode`) that turns Claude Code into a personal assistant with 38 skills — no daemon, no cloud, MIT licensed

## Details
- **npm**: https://www.npmjs.com/package/pawmode
- **License**: MIT
- **Install**: `npx pawmode`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an OpenPaw entry to the Community Skills table linking to the project and describing its built-in skills and features.
  * Note: The OpenPaw entry appears twice in the Community Skills table (duplicate entry present).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->