### PR TITLE
Add PUIUX Pilot auto-configuration CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ One hundred twenty-one production-ready plugins that extend Claude Code with dom
 | Plugin | Description |
 |--------|-------------|
 | [aws-cost-saver](https://github.com/prajapatimehul/aws-cost-saver) | AWS cost optimization scanner with 173 automated checks, ML-powered rightsizing, and Zero Hallucination Pricing - Real result: 60% cost reduction |
+| [PUIUX Pilot](https://github.com/PUIUX-Cloud/puiux-pilot) | Auto-configures Claude Code hooks, MCPs, and skills for any project. Scans 95+ project types, selects from 28+ hooks, scores quality (0-100), translates configs across AI tools. Safe: dry-run, atomic writes, backup + rollback. |
 | [a11y-audit](plugins/a11y-audit/) | Full accessibility audit with WCAG compliance checking |
 | [accessibility-checker](plugins/accessibility-checker/) | Scan for accessibility issues and fix ARIA attributes in web applications |
 | [adr-writer](plugins/adr-writer/) | Architecture Decision Records authoring and management |


### PR DESCRIPTION
## Summary
Adds [PUIUX Pilot](https://github.com/PUIUX-Cloud/puiux-pilot) to the Plugins table — an open-source CLI that auto-configures Claude Code hooks, MCPs, and skills for any project.

- Scans 95+ project types
- Selects relevant hooks and configures MCP servers based on dependencies
- Scores project quality (0-100)
- Safe by default: dry-run mode, atomic writes, backup + rollback, clean eject
- Install: `npm i -g puiux-pilot`
- License: Apache 2.0

## Type
- [x] Plugin (external CLI tool)

## Testing
Tested with Claude Code on multiple project types.

## Checklist
- [x] Follows format guidelines
- [x] Tested with Claude Code
- [x] No sensitive info (API keys, paths)
- [x] Clear descriptions
- [x] README table updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a PUIUX Pilot entry to the Plugins table in the README, including a GitHub link and brief descriptive blurb. This is a content-only documentation update to help users discover the plugin and access its source; no functional or behavioral changes were made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->