### PR TITLE
Add readme-best-practices skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,7 @@ Thirty-five curated skill modules included in this repo, with access to **15,000
 | Skill | Install | What It Teaches |
 |-------|---------|------------------|
 | [Reepl - LinkedIn Content Creation](https://github.com/reepl-io/skills) | `npx skillkit@latest install reepl-io/skills` | 18 tools for LinkedIn content management: drafts, publishing, scheduling, voice profiles, contacts, collections, templates, and AI image generation |
+| [readme-best-practices](https://github.com/ofershap/readme-best-practices) | `npx skillkit@latest install ofershap/readme-best-practices` | Teaches agents to write READMEs like landing pages. Punchline first, feature tables, copy-paste install blocks. |
 
 ### Installing Skills
 


### PR DESCRIPTION
Adds readme-best-practices - teaches agents to write READMEs like landing pages. Punchline first, feature tables, copy-paste install blocks.

https://github.com/ofershap/readme-best-practices

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added a new Community Skills entry for readme-best-practices, including installation instructions and description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->