### PR TITLE
Add claude-recap: per-topic session memory plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ One hundred twenty-one production-ready plugins that extend Claude Code with dom
 | [changelog-gen](plugins/changelog-gen/) | Generate changelogs from git history with conventional commit parsing |
 | [changelog-writer](plugins/changelog-writer/) | Detailed changelog authoring from git history and PRs |
 | [ci-debugger](plugins/ci-debugger/) | Debug CI/CD pipeline failures and fix configurations |
+| [claude-recap](https://github.com/hatawong/claude-recap) | Per-topic session memory using Shell hooks — archives each conversation topic as a separate Markdown summary. Two hooks, bash + Node.js, 100% local |
 | [code-architect](plugins/code-architect/) | Generate architecture diagrams and technical design documents |
 | [code-explainer](plugins/code-explainer/) | Explain complex code and annotate files with inline documentation |
 | [code-guardian](plugins/code-guardian/) | Automated code review, security scanning, and quality enforcement |


### PR DESCRIPTION
## Summary

- Adds [claude-recap](https://github.com/hatawong/claude-recap) to the Plugins table in alphabetical order
- claude-recap provides per-topic session memory for Claude Code using two Shell hooks (SessionStart + Stop). Each conversation topic is archived as a separate Markdown summary — bash + Node.js, 100% local, no external services

## Details

claude-recap solves the "goldfish memory" problem where Claude Code forgets everything between sessions. It:

- Automatically detects topic changes during conversation via a lightweight Stop hook
- Archives each topic as a standalone `.md` summary under `~/.memory/`
- Restores relevant context on SessionStart so the next session picks up where you left off
- Handles edge cases like compaction (cold-read fallback) and pending archives (background process)

Two hooks, zero API keys, fully local.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added claude-recap plugin to the Plugins documentation with description and reference link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->