### PR TITLE
Add Production Grade plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ One hundred twenty-one production-ready plugins that extend Claude Code with dom
 | [plan](plugins/plan/) | Structured planning with risk assessment and time estimation |
 | [pr-reviewer](plugins/pr-reviewer/) | Review pull requests with structured analysis and approve with confidence |
 | [product-shipper](plugins/product-shipper/) | Ship features end-to-end with launch checklists and rollout plans |
+| [production-grade](https://github.com/nagisanzenin/claude-code-production-grade-plugin) | 14-agent autonomous pipeline — PM, Architect, Backend, Frontend, QA, Security, Code Review, DevOps, SRE, Data Scientist, Technical Writer, Skill Maker, Polymath co-pilot. Two-wave parallel execution, brownfield-safe. |
 | [project-scaffold](plugins/project-scaffold/) | Scaffold new projects and add features with best-practice templates |
 | [prompt-optimizer](plugins/prompt-optimizer/) | Analyze and optimize AI prompts for better results |
 | [python-expert](plugins/python-expert/) | Python-specific development with type hints and idiomatic refactoring |


### PR DESCRIPTION
## Summary
- Adds the **production-grade** plugin to the Plugins table in README.md
- 14-agent autonomous pipeline (PM, Architect, Backend, Frontend, QA, Security, Code Review, DevOps, SRE, Data Scientist, Technical Writer, Skill Maker, Polymath co-pilot) with two-wave parallel execution, brownfield-safe

## Test plan
- [x] Entry placed in alphabetical order (between `product-shipper` and `project-scaffold`)
- [x] Table format matches existing entries (pipe-delimited, linked name, description)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new production-grade plugin entry to the Plugins table featuring an autonomous pipeline capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->