### PR TITLE
Add product-manager-skills to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,7 @@ Thirty-five curated skill modules included in this repo, with access to **15,000
 | Skill | Install | What It Teaches |
 |-------|---------|------------------|
 | [Reepl - LinkedIn Content Creation](https://github.com/reepl-io/skills) | `npx skillkit@latest install reepl-io/skills` | 18 tools for LinkedIn content management: drafts, publishing, scheduling, voice profiles, contacts, collections, templates, and AI image generation |
+| [Product Manager Skills](https://github.com/Digidai/product-manager-skills) | `clawhub install product-manager-skills` | Senior PM agent with 6 knowledge domains, 12 templates, and 30+ frameworks covering discovery, strategy, delivery, SaaS metrics, PM career coaching (IC to CPO), and AI product craft |
 
 ### Installing Skills
 


### PR DESCRIPTION
## Summary

- Adds [product-manager-skills](https://github.com/Digidai/product-manager-skills) to the Community Skills table
- Senior PM agent skill with 6 knowledge domains, 12 templates, and 30+ frameworks
- Covers discovery, strategy, delivery, SaaS metrics, PM career coaching (IC to CPO), and AI product craft
- Install: `clawhub install product-manager-skills`

## Details

This skill provides comprehensive product management capabilities for Claude Code, including:
- Product discovery and strategy frameworks
- Delivery and execution templates
- 32 SaaS metrics with formulas
- PM career coaching from IC to CPO level
- AI product craft guidance

GitHub: https://github.com/Digidai/product-manager-skills
ClawHub: https://clawhub.ai/Digidai/product-manager-skills

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Product Manager Skills entry to the Community Skills table with installation instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->