### PR TITLE
Add avoid-ai-writing community skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,7 @@ Thirty-five curated skill modules included in this repo, with access to **15,000
 | Skill | Install | What It Teaches |
 |-------|---------|------------------|
 | [Reepl - LinkedIn Content Creation](https://github.com/reepl-io/skills) | `npx skillkit@latest install reepl-io/skills` | 18 tools for LinkedIn content management: drafts, publishing, scheduling, voice profiles, contacts, collections, templates, and AI image generation |
+| [avoid-ai-writing](https://github.com/conorbronsdon/avoid-ai-writing) | `git clone https://github.com/conorbronsdon/avoid-ai-writing ~/.claude/skills/avoid-ai-writing` | AI writing pattern detection and rewriting (21 categories, 43 replacements) |
 
 ### Installing Skills
 


### PR DESCRIPTION
Adds avoid-ai-writing, a Claude Code skill that detects and fixes 21 categories of AI writing patterns. Includes a 43-entry word replacement table with specific alternatives, structured four-section output, and a second-pass audit. MIT licensed. https://github.com/conorbronsdon/avoid-ai-writing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Community Skills resource entry for an AI writing pattern detection and rewriting tool. The entry includes installation instructions, the GitHub repository link, and full details about the tool's capabilities for identifying and rewriting patterns across 21 distinct categories with 43 available rewrites.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->