### PR TITLE
Add BGPT MCP (scientific paper search)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Claude Code Toolkit
 
-**The most comprehensive toolkit for Claude Code -- 135 agents, 35 curated skills (+15,000 via [SkillKit](https://agenstskills.com)), 42 commands, 121 plugins, 19 hooks, 15 rules, 7 templates, 6 MCP configs, and more.**
+**The most comprehensive toolkit for Claude Code -- 135 agents, 35 curated skills (+15,000 via [SkillKit](https://agenstskills.com)), 42 commands, 121 plugins, 19 hooks, 15 rules, 7 templates, 7 MCP configs, and more.**
 
 [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
@@ -41,7 +41,7 @@ curl -fsSL https://raw.githubusercontent.com/rohitg00/awesome-claude-code-toolki
 - [Hooks](#hooks) (19 scripts)
 - [Rules](#rules) (15)
 - [Templates](#templates) (7)
-- [MCP Configs](#mcp-configs) (6)
+- [MCP Configs](#mcp-configs) (7)
 - [Contexts](#contexts) (5)
 - [Examples](#examples) (3)
 - [Setup](#setup)
@@ -651,7 +651,7 @@ cp templates/claude-md/standard.md CLAUDE.md
 
 ## MCP Configs
 
-Six curated Model Context Protocol server configurations.
+Seven curated Model Context Protocol server configurations.
 
 | Config | File | Servers Included |
 |--------|------|-----------------|
@@ -661,6 +661,7 @@ Six curated Model Context Protocol server configurations.
 | Data Science | [`data-science.json`](mcp-configs/data-science.json) | Jupyter, SQLite, PostgreSQL, Filesystem |
 | Frontend | [`frontend.json`](mcp-configs/frontend.json) | Puppeteer, Figma, Storybook |
 | DevOps | [`devops.json`](mcp-configs/devops.json) | AWS, Docker, GitHub, Terraform, Sentry |
+| Research | [`research.json`](mcp-configs/research.json) | BGPT scientific papers, Brave Search, Fetch, Memory, Filesystem |
 
 ---
 
@@ -704,7 +705,7 @@ The interactive installer clones the repo, symlinks configs, and installs plugin
 
 ```
 claude-code-toolkit/               796 files
-  plugins/                         120 plugins (220 command files)
+  plugins/                         121 plugins (220 command files)
   agents/                          135 agents across 10 categories
     core-development/              13 agents
     language-experts/              25 agents
@@ -723,7 +724,7 @@ claude-code-toolkit/               796 files
     scripts/                       19 Node.js scripts
   rules/                           15 coding rules
   templates/claude-md/             7 CLAUDE.md templates
-  mcp-configs/                     6 server configurations
+  mcp-configs/                     7 server configurations
   contexts/                        5 context modes
   examples/                        3 walkthrough examples
   setup/                           Interactive installer

--- a/mcp-configs/research.json
+++ b/mcp-configs/research.json
@@ -1,0 +1,32 @@
+{
+  "mcpServers": {
+    "bgpt": {
+      "type": "sse",
+      "url": "https://mcp.bgpt.pro/sse",
+      "description": "Search scientific papers with full-text experimental data via BGPT. 50 free searches, no API key needed."
+    },
+    "fetch": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-fetch"],
+      "description": "Fetch web pages, documentation, and research resources as markdown."
+    },
+    "memory": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-memory"],
+      "description": "Persistent knowledge graph for tracking research findings, citations, and insights across sessions."
+    },
+    "filesystem": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "<replace-with-absolute-project-path>"],
+      "description": "Read and write research notes, papers, and data files. Replace the placeholder with your project root."
+    },
+    "brave-search": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-brave-search"],
+      "env": {
+        "BRAVE_API_KEY": "<your-brave-api-key>"
+      },
+      "description": "Web search for supplementary sources, preprints, and grey literature."
+    }
+  }
+}


### PR DESCRIPTION
Adds a new **Research** MCP config featuring [BGPT MCP](https://github.com/connerlambden/bgpt-mcp) — a hosted MCP server for searching scientific papers with full-text experimental data.

**Changes:**
- New `mcp-configs/research.json` with 5 servers: BGPT, Brave Search, Fetch, Memory, Filesystem
- README updated with the new Research config row and counts (6 → 7)

**About BGPT MCP:**
- Remote server (SSE + Streamable HTTP) — no local install needed
- Tool: `search_papers` — returns structured data from full-text studies
- Free tier: 50 searches, no API key needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new "Research" MCP configuration containing five server definitions, expanding available configurations to seven.

* **Documentation**
  * Updated README, project structure, and table of contents to reflect the new MCP Config entry and the increased plugin/config counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->