### PR TITLE
Add ContextDocs to Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ One hundred twenty-one production-ready plugins that extend Claude Code with dom
 | [compliance-checker](plugins/compliance-checker/) | Regulatory compliance verification for GDPR, SOC2, and HIPAA |
 | [content-creator](plugins/content-creator/) | Technical content generation for blog posts and social media |
 | [context7-docs](plugins/context7-docs/) | Fetch up-to-date library documentation via Context7 for accurate coding |
+| [ContextDocs](https://github.com/littlebearapps/contextdocs) | Your AI agent maintains its own context files — a Claude Code plugin with an AGENTS-first model that covers Codex, Copilot, Cursor, Gemini, and 3 more tools |
 | [contract-tester](plugins/contract-tester/) | API contract testing with Pact for microservice compatibility |
 | [create-worktrees](plugins/create-worktrees/) | Git worktree management for parallel development workflows |
 | [cron-scheduler](plugins/cron-scheduler/) | Cron job configuration and schedule validation |


### PR DESCRIPTION
## Summary

Adds [ContextDocs](https://github.com/littlebearapps/contextdocs) to the Plugins table.

Your AI agent maintains its own context files — a Claude Code plugin with an AGENTS-first model that covers Codex, Copilot, Cursor, Gemini, and 3 more tools.

- **License:** MIT
- **Pure Markdown** — zero runtime dependencies
- **Install:** `/plugin add https://github.com/littlebearapps/lba-plugins`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added ContextDocs plugin to the available plugins list, offering AGENTS-first modeling and comprehensive tools coverage capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->