### PR TITLE
Add Claudify to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,7 @@ Thirty-five curated skill modules included in this repo, with access to **15,000
 | Skill | Install | What It Teaches |
 |-------|---------|------------------|
 | [Reepl - LinkedIn Content Creation](https://github.com/reepl-io/skills) | `npx skillkit@latest install reepl-io/skills` | 18 tools for LinkedIn content management: drafts, publishing, scheduling, voice profiles, contacts, collections, templates, and AI image generation |
+| [Claudify](https://claudify.tech) | `npx create-claudify` | Complete operating system for Claude Code — 1,700+ skills across 31 categories, specialist agents with persistent memory, slash commands, and automated quality checks |
 
 ### Installing Skills
 


### PR DESCRIPTION
Adds [Claudify](https://claudify.tech) to the Community Skills table.

Claudify is a complete operating system for Claude Code with 1,700+ skills across 31 categories, specialist agents with persistent memory, slash commands, and automated quality checks. One-command install via `npx create-claudify`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Claudify to the Community Skills table, including installation command and detailed description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->