### PR TITLE
Add onWatch — open-source AI API quota tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ One hundred twenty-one production-ready plugins that extend Claude Code with dom
 | [mutation-tester](plugins/mutation-tester/) | Mutation testing to measure test suite quality |
 | [n8n-workflow](plugins/n8n-workflow/) | Generate n8n automation workflows from natural language descriptions |
 | [onboarding-guide](plugins/onboarding-guide/) | New developer onboarding documentation generator |
-| [onWatch](https://github.com/onllm-dev/onwatch) | Open-source Go CLI that tracks AI API quota usage across 7 providers (Anthropic, OpenAI, GitHub Copilot, and more) with a background daemon, <50MB RAM, zero telemetry, and a Material Design 3 web dashboard |
+| [onWatch](https://github.com/onllm-dev/onwatch) | Open-source Go CLI that tracks AI API quota usage across 7 providers (Synthetic, Z.ai, Anthropic, Codex, GitHub Copilot, MiniMax, Antigravity) with a background daemon (<50 MB RAM), zero telemetry, and a Material Design 3 web dashboard |
 | [openapi-expert](plugins/openapi-expert/) | OpenAPI spec generation, validation, and client code scaffolding |
 | [optimize](plugins/optimize/) | Code optimization for performance and bundle size reduction |
 | [perf-profiler](plugins/perf-profiler/) | Performance analysis, profiling, and optimization recommendations |


### PR DESCRIPTION
## Summary

- Adds [onWatch](https://github.com/onllm-dev/onwatch) to the Plugins table (alphabetically between `n8n-workflow` and `onboarding-guide`)
- onWatch is an open-source Go CLI that tracks AI API quota usage across 7 providers including Anthropic (Claude Code), OpenAI, GitHub Copilot, and more
- Background daemon, <50MB RAM, zero telemetry, Material Design 3 web dashboard
- Works with Claude Code, Cline, Roo Code, Kilo Code
- GPL-3.0 licensed, 342+ stars

## Why it belongs here

onWatch is directly relevant to Claude Code users — it monitors Anthropic API quota usage in real time with quota reset detection, consumption rate projections, and time-to-exhaustion estimates. It helps developers avoid hitting quota limits mid-session.

## Checklist

- [x] Entry follows existing table format
- [x] Alphabetically sorted
- [x] Links to external GitHub repository
- [x] Description is concise and factual

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added onWatch plugin entry to the Plugins reference table, including a descriptive summary and a direct link for easy access.
  * This is an additive documentation update only; no existing plugin entries, behavior, or public interfaces were changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->