### PR TITLE
Add plugin: claude-cost-optimizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ One hundred twenty-one production-ready plugins that extend Claude Code with dom
 | Plugin | Description |
 |--------|-------------|
 | [aws-cost-saver](https://github.com/prajapatimehul/aws-cost-saver) | AWS cost optimization scanner with 173 automated checks, ML-powered rightsizing, and Zero Hallucination Pricing - Real result: 60% cost reduction |
+| [claude-cost-optimizer](https://github.com/Sagargupta16/claude-cost-optimizer) | Save 30-60% on Claude Code costs -- 6 deep-dive guides, 15 ranked strategies, 12 CLAUDE.md templates, token estimator, usage analyzer, and copy-paste configs |
 | [a11y-audit](plugins/a11y-audit/) | Full accessibility audit with WCAG compliance checking |
 | [accessibility-checker](plugins/accessibility-checker/) | Scan for accessibility issues and fix ARIA attributes in web applications |
 | [adr-writer](plugins/adr-writer/) | Architecture Decision Records authoring and management |


### PR DESCRIPTION
## Summary
- Added `claude-cost-optimizer` to the external plugins table in README

## What is it
[claude-cost-optimizer](https://github.com/Sagargupta16/claude-cost-optimizer) helps developers save 30-60% on Claude Code costs with:
- 6 deep-dive guides (billing mechanics, context optimization, model selection, workflow patterns, team budgeting, platform pricing)
- 15 ranked optimization strategies with effort/savings tradeoffs
- 12 CLAUDE.md templates (4 general + 5 stack-specific)
- 3 settings configs (cost-conscious, balanced, performance-first)
- Slash commands (/cost-check, /budget-mode, /quick-fix)
- Python tools: token estimator and usage analyzer

## Test plan
- [x] Entry added in alphabetical order after `aws-cost-saver`
- [x] Table formatting matches existing entries
- [x] Link verified and working

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Expanded the plugin catalog with a new entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->