### PR TITLE
feat: add ctrl by bulletproof-sh to Companion Apps & GUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -782,6 +782,7 @@ claude-code-toolkit/               800+ files
 
 | Name | Stars | Description |
 |------|-------|-------------|
+| [ctrl](https://ctrl.bulletproof.sh) | - | Pixel-art office that visualizes AI coding agents (Claude Code, Codex, Gemini) working in real time. Standalone web app + daemon, relay sharing for remote access, multi-agent support |
 | [Opcode](https://github.com/winfunc/opcode) | 21,000+ | Tauri 2 desktop GUI and toolkit for Claude Code -- create custom agents with visual editor, usage analytics, MCP integration |
 | [CloudCLI](https://github.com/siteboon/claudecodeui) | 8,400+ | Free open-source web/mobile UI for Claude Code, Cursor CLI, and Codex. Responsive design, integrated shell, file explorer, git explorer |
 | [Companion](https://github.com/The-Vibe-Company/companion) | 2,200+ | Web & mobile UI for Claude Code & Codex. Launch parallel sessions, stream responses, approve tools, session recovery |


### PR DESCRIPTION
## Summary

Adds [ctrl](https://ctrl.bulletproof.sh) to the Companion Apps & GUIs section. ctrl is a pixel-art office that visualizes AI coding agents (Claude Code, Codex, Gemini) working in real time. It's a standalone web app + daemon built by bulletproof-sh, currently in beta.

## Entry Added

```
| [ctrl](https://ctrl.bulletproof.sh) | - | Pixel-art office that visualizes AI coding agents (Claude Code, Codex, Gemini) working in real time. Standalone web app + daemon, relay sharing for remote access, multi-agent support |
```

## Why it fits here

ctrl is a companion app for AI coding agent workflows — it sits alongside your terminal session and gives you (and teammates) a live visual view of all agents working. It fits the same pattern as Poirot and TokenEater already in this section: external GUIs that complement the Claude Code experience rather than wrapping it.

I'm the developer of ctrl. Happy to answer any questions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "ctrl" companion application to the documentation. This pixel-art office visualization tool for AI coding agents offers remote access functionality and multi-agent support capabilities. The new reference is now available in both the main companion apps section and the broader ecosystem documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->