### PR TITLE
Add preflight: 24-tool MCP server for prompt quality & cost optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ Over 150 production-ready plugins that extend Claude Code with domain-specific c
 | [perf-profiler](plugins/perf-profiler/) | Performance analysis, profiling, and optimization recommendations |
 | [performance-monitor](plugins/performance-monitor/) | Profile API endpoints and run benchmarks to identify performance bottlenecks |
 | [plan](plugins/plan/) | Structured planning with risk assessment and time estimation |
+| [preflight](https://github.com/preflight-dev/preflight) | 24-tool MCP server that catches vague prompts before they cost 2-3x in wrong→fix cycles. 12-category scorecards, correction pattern learning, cross-service contract awareness, session history search with LanceDB vectors, and cost estimation. `npx preflight-dev` |
 | [pr-reviewer](plugins/pr-reviewer/) | Review pull requests with structured analysis and approve with confidence |
 | [product-shipper](plugins/product-shipper/) | Ship features end-to-end with launch checklists and rollout plans |
 | [production-grade](https://github.com/nagisanzenin/claude-code-production-grade-plugin) | 14-agent autonomous pipeline — PM, Architect, Backend, Frontend, QA, Security, Code Review, DevOps, SRE, Data Scientist, Technical Writer, Skill Maker, Polymath co-pilot. Two-wave parallel execution, brownfield-safe. |


### PR DESCRIPTION
Adds [preflight](https://github.com/preflight-dev/preflight) to the All Plugins table.

**What it does:** 24-tool MCP server that catches vague/ambiguous prompts before execution. Based on analysis of 512 Claude Code sessions (3,200+ prompts) showing 41% under 50 chars and ~30-40% token waste from correction cycles.

**Key features:**
- 12-category prompt scorecards
- Correction pattern learning (remembers past mistakes)
- Cross-service contract awareness
- Session history search (LanceDB vectors)
- Cost estimation & waste tracking

**Install:** `npx preflight-dev`

Already listed on punkpeye/awesome-mcp-servers and TensorBlock/awesome-mcp-servers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new “Preflight” plugin entry to the All Plugins table in the README, including a concise description and a direct link for quick access.
  * Improves plugin discoverability and helps users understand the plugin’s purpose and how to get started.
  * No functional or structural changes to the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->