### PR TITLE
Add Beacon Skill and Grazer Skill to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,6 +485,8 @@ Thirty-five curated skill modules included in this repo, with access to **400,00
 | [claude-skills](https://github.com/alirezarezvani/claude-skills) | `git clone` | 192 production-ready skills across 9 domains (engineering, marketing, product, compliance, C-level advisory) with 254 Python automation tools. 5,300+ stars |
 | [n8n-skills](https://github.com/czlonkowski/n8n-skills) | `git clone` | 7 complementary skills for building production-ready n8n workflows. Covers 525+ nodes, 2,653+ templates. 3,400+ stars |
 | [claude-code-best-practice](https://github.com/shanraisshan/claude-code-best-practice) | `git clone` | Comprehensive reference implementation for Claude Code configuration -- skills, subagents, hooks, commands with practical examples. 17,400+ stars |
+| [Beacon Skill](https://github.com/Scottcjn/beacon-skill) | `git clone https://github.com/Scottcjn/beacon-skill ~/.claude/skills/beacon-skill` | GitHub outreach automation -- finds repos, opens issues/PRs, tracks responses, manages multi-platform distribution campaigns. 96 stars |
+| [Grazer Skill](https://github.com/Scottcjn/grazer-skill) | `git clone https://github.com/Scottcjn/grazer-skill ~/.claude/skills/grazer-skill` | Autonomous content browsing and social posting -- monitors feeds, generates context-aware posts, manages multi-platform presence. 70 stars |
 
 ### Installing Skills
 


### PR DESCRIPTION
## Summary

Adds two community skills to the Community Skills table:

- **[Beacon Skill](https://github.com/Scottcjn/beacon-skill)** (96 stars) - GitHub outreach automation skill that finds relevant repos, opens issues/PRs, tracks responses, and manages multi-platform distribution campaigns.

- **[Grazer Skill](https://github.com/Scottcjn/grazer-skill)** (70 stars) - Autonomous content browsing and social posting skill that monitors feeds, generates context-aware posts, and manages multi-platform presence.

Both entries follow the existing `| [Name](url) | install | description |` table format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added two new community skill entries (Beacon Skill and Grazer Skill) with installation instructions and star counts to the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->