### PR TITLE
Add ORCH — CLI orchestrator for AI agent teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Over 150 production-ready plugins that extend Claude Code with domain-specific c
 | [opcode](https://github.com/winfunc/opcode) | Tauri 2 desktop GUI and toolkit for Claude Code. Manage sessions, create custom agents with visual editor, usage analytics, MCP integration. 21,000+ stars |
 | [openapi-expert](plugins/openapi-expert/) | OpenAPI spec generation, validation, and client code scaffolding |
 | [optimize](plugins/optimize/) | Code optimization for performance and bundle size reduction |
+| [ORCH](https://github.com/oxgeneral/ORCH) | CLI runtime orchestrating Claude Code, Codex, and Cursor as typed agent teams with state machine (todo→review→done), auto-retry, inter-agent messaging, goals, and TUI dashboard |
 | [peon-ping](https://github.com/PeonPing/peon-ping) | Warcraft III Peon voice notifications (+ StarCraft, Portal, Zelda) for Claude Code and other agents. Desktop banners, auto-detects SSH/devcontainers. 3,900+ stars |
 | [perf-profiler](plugins/perf-profiler/) | Performance analysis, profiling, and optimization recommendations |
 | [performance-monitor](plugins/performance-monitor/) | Profile API endpoints and run benchmarks to identify performance bottlenecks |


### PR DESCRIPTION
ORCH orchestrates Claude Code, Codex, and Cursor as typed agent teams. State machine, auto-retry, inter-agent messaging, TUI dashboard. npm: @oxgeneral/orch

## What is ORCH?

**[ORCH](https://github.com/oxgeneral/ORCH)** is a CLI runtime for managing AI agent teams with full lifecycle management:

- **State machine**: tasks flow `todo → in_progress → review → done` with mandatory review gate
- **Auto-retry**: failed agents automatically enter `retrying` state — no silent failures
- **Inter-agent messaging**: agents communicate via `orch msg send/broadcast`
- **Multi-adapter**: supports Claude Code, OpenCode, Codex, Cursor, and shell scripts
- **TUI dashboard**: real-time Ink/React terminal UI
- **Goals system**: high-level goals decomposed into tracked tasks
- **Teams**: agents organized into named teams with roles
- **Programmatic API**: `npm install @oxgeneral/orch` — use as library

## Why it fits the Plugins section

Other orchestration plugins (myclaude, vibe-kanban, oh-my-claudecode) focus on parallel agent running. ORCH adds **managed lifecycle** — the missing accountability layer for production AI workflows.

## Entry added

All Plugins table, alphabetical position (after `optimize`, before `peon-ping`):

```
| [ORCH](https://github.com/oxgeneral/ORCH) | CLI runtime orchestrating Claude Code, Codex, and Cursor as typed agent teams with state machine (todo→review→done), auto-retry, inter-agent messaging, goals, and TUI dashboard |
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new plugin entry in the All Plugins table with details on CLI runtime orchestration capabilities, including state machine management, auto-retry functionality, inter-agent messaging, goal tracking, and TUI dashboard features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->