### PR TITLE
Add fractal — recursive project management plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Over 150 production-ready plugins that extend Claude Code with domain-specific c
 | [experiment-tracker](plugins/experiment-tracker/) | ML experiment tracking with metrics logging and run comparison |
 | [explore](plugins/explore/) | Smart codebase exploration with dependency mapping and structure analysis |
 | [feature-dev](plugins/feature-dev/) | Full feature development workflow from spec to completion |
+| [fractal](https://github.com/rmolines/fractal) | Recursive project management plugin. Decomposes any goal into verifiable predicates, works on the riskiest unknown first. Features `/fractal:run` (idempotent state machine), `/fractal:init`, `/fractal:patch`, dry run mode, and incremental decomposition with re-evaluation. |
 | [finance-tracker](plugins/finance-tracker/) | Development cost tracking with time estimates and budget reporting |
 | [fix-github-issue](plugins/fix-github-issue/) | Auto-fix GitHub issues by analyzing issue details and implementing solutions |
 | [fix-pr](plugins/fix-pr/) | Fix PR review comments automatically with context-aware patches |


### PR DESCRIPTION
## Summary

Adds [fractal](https://github.com/rmolines/fractal) to the plugins table (alphabetically under "f").

**What it does:** Recursive project management for Claude Code. One primitive that decomposes any goal into verifiable predicates, works on the riskiest unknown first. The filesystem is the state — no database, no JSON.

**Key features:**
- `/fractal:run` — idempotent state machine, call repeatedly to advance the tree
- `/fractal:init` — bootstrap any goal into a predicate tree
- `/fractal:patch` — fast path for trivial leaf predicates
- Full sprint cycle: planning → delivery → review → ship
- Dry run mode — builds the full decomposition tree without executing
- Incremental decomposition with re-evaluation at each node

**Repo:** https://github.com/rmolines/fractal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added fractal plugin to the Plugins table, a recursive project management plugin featuring state machine capabilities, initialization, patching, dry-run mode, and incremental decomposition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->