### PR TITLE
Add VibeGuard to Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ Over 150 production-ready plugins that extend Claude Code with domain-specific c
 | [update-branch](plugins/update-branch/) | Rebase and update feature branches with conflict resolution |
 | [vision-specialist](plugins/vision-specialist/) | Image and visual analysis with screenshot interpretation and text extraction |
 | [vibe-kanban](https://github.com/BloopAI/vibe-kanban) | Kanban-based orchestration for 10+ coding agents (Claude Code, Codex, Gemini CLI, Copilot, Amp). Isolated git worktrees per agent, inline diff review. 23,200+ stars |
+| [VibeGuard](https://github.com/majiayu000/vibeguard) | Stop AI from hallucinating code. 88 rules + 13 hooks + 14 agents for real-time interception and static scanning across 5 languages |
 | [visual-regression](plugins/visual-regression/) | Visual regression testing with screenshot comparison |
 | [wshobson/agents](https://github.com/wshobson/agents) | 112 specialized agents, 16 multi-agent workflow orchestrators, 146 skills, 79 tools in 72 focused plugins. 31,300+ stars |
 | [web-dev](plugins/web-dev/) | Full-stack web development with app scaffolding and page generation |


### PR DESCRIPTION
Add [VibeGuard](https://github.com/majiayu000/vibeguard) to the Plugins section.

88 rules + 13 hooks + 14 agents for preventing AI code hallucinations across 5 languages.