### PR TITLE
Add zclean to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -818,6 +818,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [myclaude](https://github.com/stellarlinkco/myclaude) | 2,400+ | Multi-agent orchestration routing to Claude Code, Codex, Gemini, and OpenCode |
 | [claude-code-mcp](https://github.com/steipete/claude-code-mcp) | 1,100+ | Run Claude Code as a one-shot MCP server -- an agent in your agent |
 | [ccmanager](https://github.com/kbwo/ccmanager) | 940+ | Session manager supporting 8 coding agents with smart auto-approval |
+| [zclean](https://github.com/whynowlab/zclean) | 19+ | Kills orphaned processes left behind by Claude Code and Codex. Stops zombie node/python/esbuild from eating your RAM |
 
 ---
 


### PR DESCRIPTION
Adding [zclean](https://github.com/whynowlab/zclean) to the Ecosystem section.

After long Claude Code sessions I kept noticing my fan running with nothing visibly open. Turned out to be dozens of orphaned node/python/esbuild processes from past sessions silently eating RAM. Built zclean to find and kill them in one command.

- **Repo**: https://github.com/whynowlab/zclean
- **Stars**: 19
- **License**: MIT
- **Install**: `npm install -g zclean`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added zclean to the Ecosystem Notable projects table with project link, star count, and description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->