### PR TITLE
Add healthcare-agents to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -818,6 +818,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [myclaude](https://github.com/stellarlinkco/myclaude) | 2,400+ | Multi-agent orchestration routing to Claude Code, Codex, Gemini, and OpenCode |
 | [claude-code-mcp](https://github.com/steipete/claude-code-mcp) | 1,100+ | Run Claude Code as a one-shot MCP server -- an agent in your agent |
 | [ccmanager](https://github.com/kbwo/ccmanager) | 940+ | Session manager supporting 8 coding agents with smart auto-approval |
+| [healthcare-agents](https://github.com/ajhcs/healthcare-agents) | New | 51 specialized healthcare administration agents with MHA-level expertise across 10 divisions -- revenue cycle, compliance, quality, clinical ops, payer relations, health IT, and more |
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds [healthcare-agents](https://github.com/ajhcs/healthcare-agents) to the Ecosystem section of the README
- 51 specialized healthcare administration AI agents for Claude Code with MHA-level expertise across 10 divisions (revenue cycle, compliance, quality, clinical ops, payer relations, health IT, and more)

## Test plan
- [x] Entry follows existing table format (Name, Stars, Description)
- [x] Link points to valid GitHub repository
- [x] Placement is at the end of the Ecosystem table, consistent with ordering by star count

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added healthcare-agents entry to the Ecosystem table, showcasing 51 specialized healthcare administration agents with GitHub link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->