### PR TITLE
Add pulser — SKILL.md diagnostic CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Over 150 production-ready plugins that extend Claude Code with domain-specific c
 | [prompt-optimizer](plugins/prompt-optimizer/) | Analyze and optimize AI prompts for better results |
 | [PUIUX Pilot](https://github.com/PUIUX-Cloud/puiux-pilot) | Auto-configures Claude Code hooks, MCPs, and skills for any project. Scans 95+ project types, selects from 28+ hooks, scores quality (0-100), translates configs across AI tools. Safe: dry-run, atomic writes, backup + rollback. |
 | [python-expert](plugins/python-expert/) | Python-specific development with type hints and idiomatic refactoring |
+| [pulser](https://github.com/whynowlab/pulser) | Diagnostic CLI for Claude Code SKILL.md files — scans 8 rules, auto-classifies, prescribes fixes with templates, --fix with rollback |
 | [query-optimizer](plugins/query-optimizer/) | SQL query optimization and execution plan analysis |
 | [rag-builder](plugins/rag-builder/) | Build Retrieval-Augmented Generation pipelines |
 | [rapid-prototyper](plugins/rapid-prototyper/) | Quick prototype scaffolding with minimal viable structure |


### PR DESCRIPTION
## What is pulser?

[pulser](https://github.com/whynowlab/pulser) is a diagnostic CLI for Claude Code SKILL.md files. It scans skills against 8 rules derived from Anthropic's published principles.

**Pipeline:** Diagnose → Classify → Prescribe → Fix → Rollback

- 8 diagnostic rules
- Auto skill type classification
- Prescriptions with ready-to-use templates
- `--fix` + `pulser undo` rollback
- Works as CLI, Claude Code skill, or conversationally

```bash
npm install -g pulser-cli
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with a new plugin entry for `pulser` in the "All Plugins" table, documenting its features and capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->