### PR TITLE
Add Notch So Good — pixel-art crab companion for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,8 @@ Over 150 production-ready plugins that extend Claude Code with domain-specific c
 | [web-dev](plugins/web-dev/) | Full-stack web development with app scaffolding and page generation |
 | [workflow-optimizer](plugins/workflow-optimizer/) | Development workflow analysis and optimization recommendations |
 
+| [notch-so-good](https://github.com/deepshal99/notch-so-good) | Pixel-art crab (Chawd) lives in your Mac's notch and watches Claude Code for you. Live session timers, color-coded notifications, 13 idle animations, mouse-reactive eyes, drowsiness system. Universal binary, one-line install: `npx notch-so-good`. MIT, 130+ users |
+
 ### Installing a Plugin
 
 ```bash


### PR DESCRIPTION
Adds [Notch So Good](https://github.com/deepshal99/notch-so-good) to the Plugins section.

A pixel-art crab called Chawd lives in your MacBook's notch and watches Claude Code for you:

- Live session timers extending the Mac's notch
- Color-coded notifications when Claude needs attention
- 13 idle animations (wave, dance, sneeze, peek-a-boo, yawn, spin...)
- Mouse-reactive eyes
- Gets drowsy if idle, startled wake-up on hover
- Multi-session support with project grouping

Uses Claude Code hooks (SessionStart, Notification, Stop). MIT licensed. One-line install: `npx notch-so-good`

130+ unique cloners in first week.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the "All Plugins" table to include the notch-so-good plugin with installation instructions and project details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->