### PR TITLE
Add Untether — Telegram companion for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -794,6 +794,7 @@ claude-code-toolkit/               800+ files
 | [TokenEater](https://github.com/AThevon/TokenEater) | 179 | Native macOS menu bar app for monitoring Claude AI usage limits and watching coding sessions live |
 | [Claw](https://github.com/jamesrochabrun/Claw) | 86 | Native macOS app wrapping Claude Code SDK in Swift. Plan Mode, MCP Integration, Custom System Prompts |
 | [The Claude Protocol](https://github.com/AvivK5498/The-Claude-Protocol) | 149 | Enforcement layer wrapping Claude Code with 13 hooks -- blocks unsafe operations, enforces worktree isolation |
+| [Untether](https://github.com/littlebearapps/untether) | 12 | Telegram bridge for Claude Code (and 5 other AI agents). Send tasks by voice or text, stream progress, approve changes with inline buttons from your phone |
 
 ---
 


### PR DESCRIPTION
Adds [Untether](https://github.com/littlebearapps/untether) to the Companion Apps & GUIs section.

Untether bridges Claude Code to a Telegram bot, giving you a mobile-friendly companion interface:

- Interactive permission buttons (approve/deny/pause & outline)
- Voice note transcription for hands-free task input
- Real-time progress streaming
- Plan mode toggle per chat
- Cost tracking and budgets
- Multi-project support with worktrees
- Session resume across devices

Also supports 5 other engines (Codex, OpenCode, Pi, Gemini CLI, Amp).

MIT licensed, Python 3.12+: `uv tool install untether`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Untether to the companion apps & GUIs directory, featuring details on its Telegram-bridge functionality for voice/text task submission and progress monitoring with inline approval capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->