### PR TITLE
Add cup -- ClickUp CLI for AI coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Over 150 production-ready plugins that extend Claude Code with domain-specific c
 | [create-worktrees](plugins/create-worktrees/) | Git worktree management for parallel development workflows |
 | [cron-scheduler](plugins/cron-scheduler/) | Cron job configuration and schedule validation |
 | [css-cleaner](plugins/css-cleaner/) | Find unused CSS and consolidate stylesheets |
+| [cup](https://github.com/krodak/clickup-cli) | ClickUp CLI for AI agents with task management, sprints, and time tracking |
 | [data-privacy](plugins/data-privacy/) | Data privacy implementation with PII detection and anonymization |
 | [database-optimizer](plugins/database-optimizer/) | Database query optimization with index recommendations and EXPLAIN analysis |
 | [dead-code-finder](plugins/dead-code-finder/) | Find and remove dead code across the codebase |


### PR DESCRIPTION
Adds cup (ClickUp CLI) to the plugins table. cup is a CLI tool for managing ClickUp tasks from the terminal, built for AI coding agents. Ships as a Claude Code plugin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new ClickUp CLI plugin to the documentation, featuring task management, sprint tracking, time tracking, and interactive output formats (TTY tables, Markdown, JSON).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->