### PR TITLE
Add brood-box to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -818,6 +818,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [myclaude](https://github.com/stellarlinkco/myclaude) | 2,400+ | Multi-agent orchestration routing to Claude Code, Codex, Gemini, and OpenCode |
 | [claude-code-mcp](https://github.com/steipete/claude-code-mcp) | 1,100+ | Run Claude Code as a one-shot MCP server -- an agent in your agent |
 | [ccmanager](https://github.com/kbwo/ccmanager) | 940+ | Session manager supporting 8 coding agents with smart auto-approval |
+| [brood-box](https://github.com/stacklok/brood-box) | 10+ | Run AI coding agents (Claude Code, Codex, OpenCode) inside hardware-isolated microVMs with snapshot isolation, egress control, and MCP authorization |
 
 ---
 


### PR DESCRIPTION
Adds [brood-box](https://github.com/stacklok/brood-box) to the Ecosystem table.

brood-box is an open-source CLI tool (Apache-2.0) that runs AI coding agents (Claude Code, Codex, OpenCode) inside hardware-isolated microVMs with snapshot isolation, egress control, and MCP authorization.

Built by [Stacklok](https://github.com/stacklok). Actively maintained.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added brood-box to the ecosystem table, highlighting support for running AI coding agents in hardware-isolated microVMs with advanced security isolation and access controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->