### PR TITLE
Add cc-statistics to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -807,6 +807,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [wshobson/agents](https://github.com/wshobson/agents) | 31,300+ | 112 specialized agents, 16 orchestrators, 146 skills, 79 tools in 72 focused plugins |
 | [oh-my-claudecode](https://github.com/Yeachan-Heo/oh-my-claudecode) | 9,900+ | Teams-first multi-agent orchestration with 19 specialized agents and 28 skills |
 | [ccusage](https://github.com/ryoppippi/ccusage) | 11,500+ | CLI for analyzing Claude Code usage from local JSONL files. Offline mode, zero API calls needed |
+| [cc-statistics](https://github.com/androidZzT/cc-statistics) | 270+ | Three-in-one Claude Code stats: CLI + Web + native macOS SwiftUI panel. Token costs, code changes by language, efficiency scoring, weekly reports. Supports Codex and Cursor too |
 | [ccpm](https://github.com/automazeio/ccpm) | 7,600+ | Project management with GitHub Issues + Git worktrees for parallel agent execution |
 | [claude-code-system-prompts](https://github.com/Piebald-AI/claude-code-system-prompts) | 5,900+ | Extracted system prompts from Claude Code, updated for each release |
 | [claude-context](https://github.com/zilliztech/claude-context) | 5,600+ | Semantic code search MCP by Zilliz -- hybrid BM25 + vector search, ~40% token reduction |


### PR DESCRIPTION
Adding [cc-statistics](https://github.com/androidZzT/cc-statistics) to the Ecosystem section.

**What it does:** Three-in-one Claude Code session statistics tool — CLI, Web dashboard, and native macOS SwiftUI menu bar panel.

**Key features:**
- Token costs by model with cost estimation
- Code changes by language (git + AI tools)
- AI vs human time breakdown
- Efficiency scoring (S/A/B/C/D grade)
- Weekly/monthly Markdown reports
- Multi-project comparison
- Supports Claude Code, Codex, and Cursor
- Zero dependencies (Python stdlib only)

`pip install cc-statistics`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Ecosystem section with a new development tool entry for analytics and reporting across multiple platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->