### PR TITLE
Add claude-code-hooks (15 hooks) and cc-safe-setup (one-command installer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ Over 150 production-ready plugins that extend Claude Code with domain-specific c
 | [claude-mem](https://github.com/thedotmack/claude-mem) | Automatically captures everything Claude does, compresses with AI, injects relevant context into future sessions. SQLite + full-text search. 35,900+ stars |
 | [claude-notifications-go](https://github.com/777genius/claude-notifications-go) | Cross-platform smart notifications -- 6 types, click-to-focus, context analysis, webhooks. Single Go binary, zero deps. 340+ stars |
 | [claude-recap](https://github.com/hatawong/claude-recap) | Per-topic session memory using Shell hooks — archives each conversation topic as a separate Markdown summary. Two hooks, bash + Node.js, 100% local |
+| [claude-code-hooks](https://github.com/yurukusa/claude-code-hooks) | 15 production-tested hooks from 160+ hours of autonomous operation. Destructive command blocker (rm -rf/NFS mount detection), branch guard, syntax check, context monitor, permission auto-approver, and more. Bash, zero deps |
+| [cc-safe-setup](https://github.com/yurukusa/cc-safe-setup) | One command (`npx cc-safe-setup`) to install 6 essential safety hooks in 10 seconds. Built after real incidents: NTFS junction data loss, NFS mount deletion. Zero dependencies |
 | [claude-supermemory](https://github.com/supermemoryai/claude-supermemory) | Persistent memory across sessions and projects using Supermemory. User profile injection at session start, automatic conversation capture. 2,300+ stars |
 | [code-architect](plugins/code-architect/) | Generate architecture diagrams and technical design documents |
 | [code-explainer](plugins/code-explainer/) | Explain complex code and annotate files with inline documentation |


### PR DESCRIPTION
## What's being added

### claude-code-hooks
- **15 production-tested hooks** from 160+ hours of autonomous Claude Code operation
- Destructive command blocker (rm -rf, git reset --hard, NFS mount detection)
- Branch guard, syntax check, context monitor, permission auto-approver
- Bash, zero dependencies, MIT license
- GitHub: https://github.com/yurukusa/claude-code-hooks

### cc-safe-setup
- **One command** (`npx cc-safe-setup`) installs 6 essential safety hooks in 10 seconds
- Built after real incidents: [NTFS junction data loss](https://github.com/anthropics/claude-code/issues/36339), [NFS mount deletion](https://github.com/anthropics/claude-code/issues/36640)
- Zero dependencies, dry-run mode, clean uninstall
- GitHub: https://github.com/yurukusa/cc-safe-setup
- npm: [cc-safe-setup](https://www.npmjs.com/package/cc-safe-setup)

Both are actively maintained and used in production.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added two new plugins to the plugins reference section. `claude-code-hooks` provides production-tested Bash safety hooks including blockers, guards, and comprehensive monitoring with approval behaviors. `cc-safe-setup` offers a one-command npx installer that streamlines deployment of six safety hooks with minimal configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->