### PR TITLE
Add codetape — AI coding documentation sync tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Over 150 production-ready plugins that extend Claude Code with domain-specific c
 | [discuss](plugins/discuss/) | Debate implementation approaches with structured pros and cons analysis |
 | [discoclaw](https://github.com/DiscoClaw/discoclaw) | Personal AI orchestrator that bridges Discord to Claude Code with durable memory, task tracking, and cron-based automation |
 | [dna-claude-analysis](https://github.com/shmlkv/dna-claude-analysis) | Personal genome analysis toolkit that analyzes raw DNA data across 17 categories and generates a terminal-style HTML dashboard |
+| [codetape](https://github.com/888wing/codetape) | The flight recorder for AI coding — auto-records semantic traces and syncs README, CHANGELOG, CLAUDE.md. Zero deps. `npx codetape init` |
 | [doc-forge](plugins/doc-forge/) | Documentation generation, API docs, and README maintenance |
 | [docker-helper](plugins/docker-helper/) | Build optimized Docker images and improve Dockerfile best practices |
 | [double-check](plugins/double-check/) | Verify code correctness with systematic second-pass analysis |


### PR DESCRIPTION
Adds [Codetape](https://github.com/888wing/codetape) to the plugins table.

Codetape is a Claude Code skill that automatically records semantic traces of code changes and syncs documentation (README, CHANGELOG, CLAUDE.md, ARCHITECTURE.md).

- 7 slash commands, zero dependencies, fully local
- npm: `npx codetape init`
- Website: https://codetape.win
- MIT licensed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated supported plugins list to include `codetape`, a plugin that records semantic traces and syncs documentation files with initialization support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->