### PR TITLE
Add claude-code-hooks SDK to hooks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,6 +641,12 @@ Nineteen hook scripts covering all eight Claude Code lifecycle events. Place `ho
 | `notification-log.js` | Notification | Log notifications for later review |
 | `prompt-check.js` | UserPromptSubmit | Detect vague prompts, suggest clarification |
 
+### Related SDKs
+
+If you prefer a typed, npm-installable foundation for writing hooks rather than raw scripts:
+
+- [claude-code-hooks](https://github.com/Payshak/claude-code-hooks) — TypeScript SDK with `defineHook()`, typed event payloads for all 5 hook events, response builders, and unit-testable `.handle()` method. Zero dependencies.
+
 ### Installing Hooks
 
 ```bash


### PR DESCRIPTION
Hey! Love the toolkit — the breadth of coverage here is impressive.

I built `claude-code-hooks`, an npm-native TypeScript SDK for writing Claude Code hooks. Rather than another collection of scripts, it's the typed foundation you'd use to build them: `defineHook()` with fully typed payloads for all five hook events, response builders (`allow()`, `block()`, `inject()`), and a `.handle()` method so you can unit test hooks without running Claude Code at all.

I've added a small "Related SDKs" note to the hooks section pointing to it — felt like a natural complement to the 19 hook scripts already there, for developers who want to build their own on top of a typed API.

**Links:** [GitHub](https://github.com/Payshak/claude-code-hooks) · Zero dependencies · MIT

Happy to tweak the wording if it doesn't fit the style you're going for.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new "Related SDKs" section in the Hooks documentation with a reference to an external TypeScript SDK offering hook definition APIs, typed payloads, response builders, and testable methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->