### PR TITLE
Add Global Chat MCP server to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -818,6 +818,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [myclaude](https://github.com/stellarlinkco/myclaude) | 2,400+ | Multi-agent orchestration routing to Claude Code, Codex, Gemini, and OpenCode |
 | [claude-code-mcp](https://github.com/steipete/claude-code-mcp) | 1,100+ | Run Claude Code as a one-shot MCP server -- an agent in your agent |
 | [ccmanager](https://github.com/kbwo/ccmanager) | 940+ | Session manager supporting 8 coding agents with smart auto-approval |
+| [Global Chat](https://github.com/pumanitro/global-chat) | -- | Cross-protocol MCP server discovery -- search 18K+ servers across 6+ registries. Also supports A2A and agents.txt. Free agents.txt validator. npm: `@global-chat/mcp-server` |
 
 ---
 


### PR DESCRIPTION
Adds [Global Chat](https://github.com/pumanitro/global-chat) to the **Ecosystem** section.

Global Chat is an MCP server for cross-protocol agent discovery — it lets Claude Code search 18,000+ MCP servers across 6+ registries (mcp.so, Glama.ai, Smithery, Cursor Directory, etc.) and also supports A2A and agents.txt protocols. Includes a free agents.txt validator.

- Website: https://global-chat.io
- npm: `@global-chat/mcp-server`
- Protocols: MCP, A2A, agents.txt
- Free and open source (MIT)

Useful for Claude Code users who need to discover and evaluate MCP servers across the fragmented registry ecosystem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Global Chat to the ecosystem—a cross-protocol MCP server discovery platform supporting 18K+ servers across 6+ registries, featuring A2A compatibility and a free agents.txt validator for seamless server integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->