### PR TITLE
Add Skillfold to Ecosystem section

### DIFF
--- a/README.md
+++ b/README.md
@@ -818,7 +818,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [myclaude](https://github.com/stellarlinkco/myclaude) | 2,400+ | Multi-agent orchestration routing to Claude Code, Codex, Gemini, and OpenCode |
 | [claude-code-mcp](https://github.com/steipete/claude-code-mcp) | 1,100+ | Run Claude Code as a one-shot MCP server -- an agent in your agent |
 | [ccmanager](https://github.com/kbwo/ccmanager) | 940+ | Session manager supporting 8 coding agents with smart auto-approval |
-| [Skillfold](https://github.com/byronxlg/skillfold) | -- | YAML compiler for multi-agent pipelines. Composes skills, validates state, generates orchestrators from team flow definitions. Compiles to the Agent Skills standard |
+| [Skillfold](https://github.com/byronxlg/skillfold) | -- | YAML compiler for multi-agent pipelines. Composes skills, validates state, generates orchestrators from team flow definitions. Compiles to the Agent Skills standard (supports 38+ platforms) |
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds [Skillfold](https://github.com/byronxlg/skillfold) to the Ecosystem table in README.md

Skillfold is a YAML compiler for multi-agent AI pipelines. It composes atomic skills into agents, validates typed state schemas, and generates orchestrators from team flow definitions with conditional routing, loops, and parallel maps. Output compiles to the Agent Skills standard (SKILL.md files), supporting 12 platforms including Claude Code, Cursor, Codex, and Gemini CLI.

- npm package: [skillfold](https://www.npmjs.com/package/skillfold)
- Docs: [skillfold.dev](https://byronxlg.github.io/skillfold/)
- Includes a Claude Code plugin with 11 library skills and a `/skillfold` slash command

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new Ecosystem entry for Skillfold, including a GitHub link and a description of its YAML-based multi-agent pipeline capabilities (skill composition, state validation, orchestrator generation, and compilation to the Agent Skills standard across 12 platforms).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->