### PR TITLE
Add GAAI Framework to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -818,6 +818,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [myclaude](https://github.com/stellarlinkco/myclaude) | 2,400+ | Multi-agent orchestration routing to Claude Code, Codex, Gemini, and OpenCode |
 | [claude-code-mcp](https://github.com/steipete/claude-code-mcp) | 1,100+ | Run Claude Code as a one-shot MCP server -- an agent in your agent |
 | [ccmanager](https://github.com/kbwo/ccmanager) | 940+ | Session manager supporting 8 coding agents with smart auto-approval |
+| [GAAI Framework](https://github.com/Fr-e-d/GAAI-framework) | 95+ | Drop-in governance layer (.gaai/ folder) -- backlog authorization, cross-session memory, decision tracking, QA gates, autonomous delivery daemon. Claude Code + Cursor + Codex CLI + Gemini CLI |
 
 ---
 


### PR DESCRIPTION
Adds [GAAI Framework](https://github.com/Fr-e-d/GAAI-framework) to the Ecosystem table.

**What it is:** A drop-in `.gaai/` folder that adds governed delivery to AI coding tools. Agents remember decisions across sessions, only build what's in the backlog, and pass QA before shipping. Optional daemon delivers stories autonomously in parallel.

**Why it fits Ecosystem:** GAAI is a governance layer for AI coding tools — similar in scope to ccpm (project management) and oh-my-claudecode (multi-agent orchestration), but focused on SDLC governance (backlog, memory, QA gates, decision tracking).

**Multi-tool:** Works with Claude Code (deep integration), Cursor, Codex CLI, Gemini CLI, Windsurf. Markdown + YAML + bash, zero dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added GAAI Framework to the ecosystem section in the README, highlighting its governance layer capabilities including backlog authorization, cross-session memory, decision tracking, QA gates, and autonomous delivery functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->