### PR TITLE
Add skill: DevOps Agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,6 +486,7 @@ Thirty-five curated skill modules included in this repo, with access to **400,00
 | [n8n-skills](https://github.com/czlonkowski/n8n-skills) | `git clone` | 7 complementary skills for building production-ready n8n workflows. Covers 525+ nodes, 2,653+ templates. 3,400+ stars |
 | [claude-code-best-practice](https://github.com/shanraisshan/claude-code-best-practice) | `git clone` | Comprehensive reference implementation for Claude Code configuration -- skills, subagents, hooks, commands with practical examples. 17,400+ stars |
 
+| [DevOps Agent](https://github.com/fullstackcrew-alpha/skill-devops-agent) | `git clone https://github.com/fullstackcrew-alpha/skill-devops-agent` | One-click deploy, monitoring setup (Prometheus+Grafana), scheduled backups, and fault diagnosis with safety-first design including confirmation prompts, dry-run, and snapshot rollback |
 ### Installing Skills
 
 **Browse and install via SkillKit** (recommended):


### PR DESCRIPTION
## New Skill: DevOps Agent

**DevOps Agent** — One-click deploy, monitoring setup (Prometheus+Grafana), scheduled backups, and fault diagnosis with safety-first design including confirmation prompts, dry-run, and snapshot rollback

- **GitHub**: https://github.com/fullstackcrew-alpha/skill-devops-agent
- **ClawHub**: https://clawhub.ai/s/devops-agent
- **Install**: `clawhub install devops-agent`
- **License**: MIT

Published by [FullStackCrew](https://github.com/fullstackcrew-alpha).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added DevOps Agent to the Community Skills table, featuring one-click deployment, Prometheus+Grafana monitoring integration, scheduled backups, and automated fault diagnosis with dry-run and snapshot rollback capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->