### PR TITLE
Add skill: CN Content Matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,6 +486,7 @@ Thirty-five curated skill modules included in this repo, with access to **400,00
 | [n8n-skills](https://github.com/czlonkowski/n8n-skills) | `git clone` | 7 complementary skills for building production-ready n8n workflows. Covers 525+ nodes, 2,653+ templates. 3,400+ stars |
 | [claude-code-best-practice](https://github.com/shanraisshan/claude-code-best-practice) | `git clone` | Comprehensive reference implementation for Claude Code configuration -- skills, subagents, hooks, commands with practical examples. 17,400+ stars |
 
+| [CN Content Matrix](https://github.com/fullstackcrew-alpha/skill-cn-content-matrix) | `git clone https://github.com/fullstackcrew-alpha/skill-cn-content-matrix` | Chinese multi-platform content generator for Xiaohongshu, WeChat, Douyin, and Bilibili with true style transfer, compliance review, and sensitive word detection |
 ### Installing Skills
 
 **Browse and install via SkillKit** (recommended):


### PR DESCRIPTION
## New Skill: CN Content Matrix

**CN Content Matrix** — Chinese multi-platform content generator for Xiaohongshu, WeChat, Douyin, and Bilibili with true style transfer, compliance review, and sensitive word detection

- **GitHub**: https://github.com/fullstackcrew-alpha/skill-cn-content-matrix
- **ClawHub**: https://clawhub.ai/s/cn-content-matrix
- **Install**: `clawhub install cn-content-matrix`
- **License**: MIT

Published by [FullStackCrew](https://github.com/fullstackcrew-alpha).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added "CN Content Matrix" community skill, featuring Chinese multi-platform content generation with style transfer and compliance checking capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->