### PR TITLE
Add new-skill: naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,6 +485,7 @@ Thirty-five curated skill modules included in this repo, with access to **400,00
 | [claude-skills](https://github.com/alirezarezvani/claude-skills) | `git clone` | 192 production-ready skills across 9 domains (engineering, marketing, product, compliance, C-level advisory) with 254 Python automation tools. 5,300+ stars |
 | [n8n-skills](https://github.com/czlonkowski/n8n-skills) | `git clone` | 7 complementary skills for building production-ready n8n workflows. Covers 525+ nodes, 2,653+ templates. 3,400+ stars |
 | [claude-code-best-practice](https://github.com/shanraisshan/claude-code-best-practice) | `git clone` | Comprehensive reference implementation for Claude Code configuration -- skills, subagents, hooks, commands with practical examples. 17,400+ stars |
+| [naming](https://github.com/glacierphonk/naming) | `git clone https://github.com/glacierphonk/naming ~/.claude/skills/naming` | Metaphor-driven naming for products, SaaS, brands, bots, and open source projects. Produces memorable, meaningful names |
 
 ### Installing Skills
 


### PR DESCRIPTION
Adds the naming skill to the Community Skills table.

A Claude Code skill for metaphor-driven naming of products, SaaS, brands, bots, and open source projects. Structured process that produces memorable, meaningful names instead of generic AI-generated suggestions. MIT licensed.

https://github.com/glacierphonk/naming

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Community Skill entry for a naming utility, including GitHub link and installation instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->