### PR TITLE
Add obey — rule enforcement plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Over 150 production-ready plugins that extend Claude Code with domain-specific c
 | [onboarding-guide](plugins/onboarding-guide/) | New developer onboarding documentation generator |
 | [oh-my-claudecode](https://github.com/Yeachan-Heo/oh-my-claudecode) | Teams-first multi-agent orchestration. 19 specialized agents, 28 skills. Full autonomous execution, Socratic questioning, N coordinated agents. 9,900+ stars |
 | [onWatch](https://github.com/onllm-dev/onwatch) | Open-source Go CLI that tracks AI API quota usage across 7 providers (Synthetic, Z.ai, Anthropic, Codex, GitHub Copilot, MiniMax, Antigravity) with a background daemon (<50 MB RAM), zero telemetry, and a Material Design 3 web dashboard |
+| [obey](https://github.com/Lexxes-Projects/obey) | Rule enforcement plugin. Save rules with natural language, enforce with 17 lifecycle hooks. Three scopes (global, stack-specific, project-local), active blocking via PreToolUse, completion checklists via Stop hook, audit trail, auto-detects rule-like language. Cross-platform. |
 | [opcode](https://github.com/winfunc/opcode) | Tauri 2 desktop GUI and toolkit for Claude Code. Manage sessions, create custom agents with visual editor, usage analytics, MCP integration. 21,000+ stars |
 | [openapi-expert](plugins/openapi-expert/) | OpenAPI spec generation, validation, and client code scaffolding |
 | [optimize](plugins/optimize/) | Code optimization for performance and bundle size reduction |


### PR DESCRIPTION
Adds [obey](https://github.com/Lexxes-Projects/obey) to the Plugins table.

**What it does:** Claude Code plugin that makes Claude follow user rules. Save rules with natural language (`/remember never push to main`), enforce with 17 lifecycle hooks, three scopes (global/stack/project).

**Category:** Plugin
**License:** MIT

Placed alphabetically between `onWatch` and `opcode`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the `obey` plugin to the plugins directory documentation, highlighting its rule enforcement capabilities including natural-language rule saving and enforcement, lifecycle hook integration (`PreToolUse` and `Stop`), customizable scoping options, audit trail functionality, automatic rule-like language detection, and cross-platform support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->