### PR TITLE
Add cozempic — context weight-loss for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ One hundred twenty-one production-ready plugins that extend Claude Code with dom
 | [content-creator](plugins/content-creator/) | Technical content generation for blog posts and social media |
 | [context7-docs](plugins/context7-docs/) | Fetch up-to-date library documentation via Context7 for accurate coding |
 | [contract-tester](plugins/contract-tester/) | API contract testing with Pact for microservice compatibility |
+| [cozempic](https://github.com/Ruya-AI/cozempic) | ✨ v1.2.x — Self-updating now, atomic writes, strict session guard, zero false positives on team detection. 13 pruning strategies, Agent Team protection, MCP server, JSONL doctor. Install: `/plugin marketplace add Ruya-AI/cozempic` |
 | [create-worktrees](plugins/create-worktrees/) | Git worktree management for parallel development workflows |
 | [cron-scheduler](plugins/cron-scheduler/) | Cron job configuration and schedule validation |
 | [css-cleaner](plugins/css-cleaner/) | Find unused CSS and consolidate stylesheets |


### PR DESCRIPTION
✨ v1.2.x — Self-updating now, atomic writes, strict session guard, zero false positives on team detection.

**[cozempic](https://github.com/Ruya-AI/cozempic)** is a context weight-loss CLI + plugin for Claude Code. Prunes bloated JSONL sessions with 13 strategies, protects Agent Teams from compaction loss with schema-first detection, ships a 5-tool MCP server, and auto-updates on startup.

- Zero external dependencies
- `pip install cozempic` + `/plugin marketplace add Ruya-AI/cozempic`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the cozempic plugin, including installation instructions and GitHub repository reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->