### PR TITLE
Add Claude Command Center workspace template

### DIFF
--- a/README.md
+++ b/README.md
@@ -818,6 +818,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [myclaude](https://github.com/stellarlinkco/myclaude) | 2,400+ | Multi-agent orchestration routing to Claude Code, Codex, Gemini, and OpenCode |
 | [claude-code-mcp](https://github.com/steipete/claude-code-mcp) | 1,100+ | Run Claude Code as a one-shot MCP server -- an agent in your agent |
 | [ccmanager](https://github.com/kbwo/ccmanager) | 940+ | Session manager supporting 8 coding agents with smart auto-approval |
+| [Claude Command Center](https://github.com/tuning-labs-oss/claude-command-center) | -- | Production-tested workspace template with session hooks, structured memory (4 types), multi-domain routing, daily task tracking, and interactive /setup onboarding. 6 domain templates, pre-commit safety, example skills |
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds Claude Command Center to the Ecosystem section
- Battle-tested workspace template with session persistence hooks, structured memory system (4 types), multi-domain routing (coding/marketing/financial/support/ops/office-admin), daily open items tracking, and an interactive /setup interview that configures everything from user answers
- MIT licensed

## Details
- **Session hooks**: Auto-save/restore state between sessions (session-start.sh, session-end.sh)
- **Memory system**: 4 types -- auto-memory, project memory, lessons-learned, session logs
- **Multi-domain routing**: 6 domain templates with scoped CLAUDE.md per domain
- **Daily task tracking**: Open items carried across sessions automatically
- **Interactive onboarding**: `/setup` skill interviews user and configures the workspace
- **Pre-commit safety**: Hooks to prevent committing secrets or breaking changes
- **Example skills**: Ready-to-use skill templates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Claude Command Center to the Ecosystem table, documenting its workspace template features including session hooks, structured memory systems, multi-domain routing, daily task tracking, interactive onboarding setup, domain templates, pre-commit safety checks, and example skills.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->