### PR TITLE
Add skill: moyu — anti-over-engineering

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,6 +485,7 @@ Thirty-five curated skill modules included in this repo, with access to **400,00
 | [claude-skills](https://github.com/alirezarezvani/claude-skills) | `git clone` | 192 production-ready skills across 9 domains (engineering, marketing, product, compliance, C-level advisory) with 254 Python automation tools. 5,300+ stars |
 | [n8n-skills](https://github.com/czlonkowski/n8n-skills) | `git clone` | 7 complementary skills for building production-ready n8n workflows. Covers 525+ nodes, 2,653+ templates. 3,400+ stars |
 | [claude-code-best-practice](https://github.com/shanraisshan/claude-code-best-practice) | `git clone` | Comprehensive reference implementation for Claude Code configuration -- skills, subagents, hooks, commands with practical examples. 17,400+ stars |
+| [moyu](https://github.com/uucz/moyu) | `claude skill install --url https://github.com/uucz/moyu --skill moyu` | Anti-over-engineering skill that teaches AI restraint. 5 variants (standard/lite/strict/en/ja), 10 platforms. Benchmarked: 66% code reduction vs baseline |
 
 ### Installing Skills
 


### PR DESCRIPTION
Adds [moyu](https://github.com/uucz/moyu) to the Community Skills section.

**What it does:** Anti-over-engineering skill that teaches AI coding agents restraint — only change what was asked, simplest solution first, ask when unsure.

- 5 variants: standard (zh/en/ja), lite, strict
- 10 platforms: Claude Code, Cursor, Codex, VSCode, Windsurf, Cline, Kiro, CodeBuddy, Antigravity, OpenCode
- Benchmarked: 66% code reduction vs baseline across 6 controlled experiments

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new community skill "moyu" to the available skills list, including installation instructions and support details for multiple platforms and variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->