### PR TITLE
Add tokburn to companion apps section

### DIFF
--- a/README.md
+++ b/README.md
@@ -794,6 +794,7 @@ claude-code-toolkit/               800+ files
 | [TokenEater](https://github.com/AThevon/TokenEater) | 179 | Native macOS menu bar app for monitoring Claude AI usage limits and watching coding sessions live |
 | [Claw](https://github.com/jamesrochabrun/Claw) | 86 | Native macOS app wrapping Claude Code SDK in Swift. Plan Mode, MCP Integration, Custom System Prompts |
 | [The Claude Protocol](https://github.com/AvivK5498/The-Claude-Protocol) | 149 | Enforcement layer wrapping Claude Code with 13 hooks -- blocks unsafe operations, enforces worktree isolation |
+| [tokburn](https://github.com/lsvishaal/tokburn) | 3 | Local analytics dashboard for Claude Code -- calculates API-equivalent costs, detects waste patterns (repeated reads, floundering, cost outliers), serves web UI + REST API. Zero network calls, zero accounts, zero telemetry. `uvx tokburn serve`. |
 
 ---
 


### PR DESCRIPTION
Adding **[tokburn](https://github.com/lsvishaal/tokburn)** — a pip-installable local dashboard for Claude Code session analytics.

**What it does:** Reads `~/.claude/projects/` JSONL files, calculates equivalent API costs using published model pricing, runs 4 waste detection heuristics, serves a web dashboard on localhost.

**Differentiators vs existing entries:**
- pip-installable (no Node.js)
- Browser-based dashboard (not CLI/terminal)
- Waste detection engine (repeated reads, floundering, outliers, long sessions)
- Full REST API with Swagger

**Links:** [GitHub](https://github.com/lsvishaal/tokburn) | [PyPI](https://pypi.org/project/tokburn/) | MIT | 19 tests, zero network calls

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added `tokburn` to the Companion Apps & GUIs section—a local analytics dashboard for monitoring API costs, identifying waste patterns, and optimizing usage through a web UI and REST API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->