### PR TITLE
Add oss-autopilot plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Over 150 production-ready plugins that extend Claude Code with domain-specific c
 | [opcode](https://github.com/winfunc/opcode) | Tauri 2 desktop GUI and toolkit for Claude Code. Manage sessions, create custom agents with visual editor, usage analytics, MCP integration. 21,000+ stars |
 | [openapi-expert](plugins/openapi-expert/) | OpenAPI spec generation, validation, and client code scaffolding |
 | [optimize](plugins/optimize/) | Code optimization for performance and bundle size reduction |
+| [oss-autopilot](https://github.com/costajohnt/oss-autopilot) | Open source contribution manager — tracks PRs across repos, discovers issues, diagnoses CI failures, drafts maintainer responses. 7 agents, interactive commands, MCP server. Install: `/plugin marketplace add costajohnt/oss-autopilot` |
 | [peon-ping](https://github.com/PeonPing/peon-ping) | Warcraft III Peon voice notifications (+ StarCraft, Portal, Zelda) for Claude Code and other agents. Desktop banners, auto-detects SSH/devcontainers. 3,900+ stars |
 | [perf-profiler](plugins/perf-profiler/) | Performance analysis, profiling, and optimization recommendations |
 | [performance-monitor](plugins/performance-monitor/) | Profile API endpoints and run benchmarks to identify performance bottlenecks |


### PR DESCRIPTION
Adds [oss-autopilot](https://github.com/costajohnt/oss-autopilot) to the Plugins table.

OSS Autopilot is an open source contribution manager that ships as a Claude Code plugin with 7 specialized agents, interactive commands (`/oss`, `/oss-search`, `/oss-help`), and an MCP server. Tracks PRs across repos, discovers contributable issues, diagnoses CI failures, and drafts maintainer responses.

Install: `/plugin marketplace add costajohnt/oss-autopilot`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the `oss-autopilot` plugin to the plugins registry with installation instructions, enabling users to install and use this new plugin for contribution and CI/PR response capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->