### PR TITLE
Add skills-janitor - skill hygiene plugin (9 actions, zero deps)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ Over 150 production-ready plugins that extend Claude Code with domain-specific c
 ### All Plugins
 
 | Plugin | Description |
-| [skills-janitor](https://github.com/khendzel/skills-janitor) | Audit, deduplicate, check, fix, and track usage of your Claude Code skills. 9 slash commands, zero dependencies |
 |--------|-------------|
+| [skills-janitor](https://github.com/khendzel/skills-janitor) | Audit, deduplicate, check, fix, and track usage of your Claude Code skills. 9 slash commands, zero dependencies |
 | [aws-cost-saver](https://github.com/prajapatimehul/aws-cost-saver) | AWS cost optimization scanner with 173 automated checks, ML-powered rightsizing, and Zero Hallucination Pricing - Real result: 60% cost reduction |
 | [claude-code-mcp](https://github.com/steipete/claude-code-mcp) | Run Claude Code as a one-shot MCP server -- an agent in your agent. Permissions bypassed automatically. By Peter Steinberger. 1,100+ stars |
 | [claude-code-system-prompts](https://github.com/Piebald-AI/claude-code-system-prompts) | Extracted system prompts from Claude Code -- 18 builtin tool descriptions, sub-agent prompts, utility prompts. Updated for each release. 5,900+ stars |


### PR DESCRIPTION
## [skills-janitor](https://github.com/khendzel/skills-janitor)

Audit, deduplicate, check, fix, and track usage of your Claude Code skills. 9 slash commands, zero dependencies.

**Install:**
```
/plugin marketplace add khendzel/skills-janitor
/plugin install skills-janitor
```

![demo](https://raw.githubusercontent.com/khendzel/skills-janitor/main/demo.gif)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "skills-janitor" entry to the plugins list in the README, including its short description and repository link.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->