### PR TITLE
Add claude-sounds — audio feedback plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ curl -fsSL https://raw.githubusercontent.com/rohitg00/awesome-claude-code-toolki
 ---
 
 ## Plugins
-| [claude-sounds](https://github.com/culminationAI/claude-sounds) | - | Your Claude Code shouldn't be silent. Sound effects for all hooks — spells, chimes, clicks. Drop mp3s to customize. |
 
 Over 150 production-ready plugins that extend Claude Code with domain-specific capabilities.
 
@@ -100,6 +99,7 @@ Over 150 production-ready plugins that extend Claude Code with domain-specific c
 | [claude-mem](https://github.com/thedotmack/claude-mem) | Automatically captures everything Claude does, compresses with AI, injects relevant context into future sessions. SQLite + full-text search. 35,900+ stars |
 | [claude-notifications-go](https://github.com/777genius/claude-notifications-go) | Cross-platform smart notifications -- 6 types, click-to-focus, context analysis, webhooks. Single Go binary, zero deps. 340+ stars |
 | [claude-recap](https://github.com/hatawong/claude-recap) | Per-topic session memory using Shell hooks — archives each conversation topic as a separate Markdown summary. Two hooks, bash + Node.js, 100% local |
+| [claude-sounds](https://github.com/culminationAI/claude-sounds) | Audio feedback for Claude Code hooks — 10 events, 21 sounds, random rotation. macOS (`afplay`). |
 | [claude-supermemory](https://github.com/supermemoryai/claude-supermemory) | Persistent memory across sessions and projects using Supermemory. User profile injection at session start, automatic conversation capture. 2,300+ stars |
 | [code-architect](plugins/code-architect/) | Generate architecture diagrams and technical design documents |
 | [code-explainer](plugins/code-explainer/) | Explain complex code and annotate files with inline documentation |


### PR DESCRIPTION
Adds [claude-sounds](https://github.com/culminationAI/claude-sounds) — Your Claude Code shouldn't be silent. Sound effects for all hooks — spells, chimes, clicks. Drop mp3s to customize.

10 hook events, 21 sounds, random rotation, fully customizable. macOS (`afplay`).

Install:
```
claude plugins marketplace add https://github.com/culminationAI/claude-marketplace
claude plugins install claude-sounds@culmination-marketplace
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added the "claude-sounds" plugin to the Plugins documentation, describing audio feedback for Claude Code hooks (multiple events, assorted sounds, random rotation, macOS playback support).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->