### PR TITLE
feat: add OpenClaw ecosystem tools to Ecosystem section

### DIFF
--- a/README.md
+++ b/README.md
@@ -818,6 +818,9 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [myclaude](https://github.com/stellarlinkco/myclaude) | 2,400+ | Multi-agent orchestration routing to Claude Code, Codex, Gemini, and OpenCode |
 | [claude-code-mcp](https://github.com/steipete/claude-code-mcp) | 1,100+ | Run Claude Code as a one-shot MCP server -- an agent in your agent |
 | [ccmanager](https://github.com/kbwo/ccmanager) | 940+ | Session manager supporting 8 coding agents with smart auto-approval |
+| [openclaw-self-healing](https://github.com/Ramsbaby/openclaw-self-healing) | 32+ | 4-tier autonomous crash recovery for Claude Code and any service — 64% auto-resolved, LLM-agnostic (Claude/GPT-4/Gemini/Ollama), Prometheus metrics |
+| [openclaw-memorybox](https://github.com/Ramsbaby/openclaw-memorybox) | 8+ | Memory hygiene CLI for Claude Code — prevents context overflow crashes, 83% MEMORY.md size reduction, zero dependencies |
+| [openclaw-self-evolving](https://github.com/Ramsbaby/openclaw-self-evolving) | 2+ | Weekly self-improvement pipeline — scans Claude Code logs, proposes CLAUDE.md/AGENTS.md rule changes, zero API cost |
 
 ---
 


### PR DESCRIPTION
## Summary

Adds three battle-tested Claude Code tooling projects from the OpenClaw ecosystem to the **Ecosystem** section:

| Project | Stars | What it does |
|---------|-------|-------------|
| [openclaw-self-healing](https://github.com/Ramsbaby/openclaw-self-healing) | ★32 | 4-tier autonomous crash recovery — 64% auto-resolved, LLM-agnostic (Claude/GPT-4/Gemini/Ollama), Prometheus metrics |
| [openclaw-memorybox](https://github.com/Ramsbaby/openclaw-memorybox) | ★8 | Memory hygiene CLI — prevents context overflow crashes, 83% MEMORY.md size reduction, zero dependencies |
| [openclaw-self-evolving](https://github.com/Ramsbaby/openclaw-self-evolving) | ★2 | Weekly self-improvement pipeline — scans Claude Code session logs, proposes CLAUDE.md/AGENTS.md rule changes, zero API cost |

All three are MIT licensed and battle-tested on a production instance running 24/7 with 48 crons.

**self-healing** and **memorybox** are directly useful alongside any Claude Code setup. **self-evolving** is unique — it addresses the problem of agents making the same mistake repeatedly by automating log review and rule proposals.

They fit the Ecosystem section well alongside existing entries like `claude-mem` and `claude-code-mcp`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added three new ecosystem projects to the README: openclaw-self-healing, openclaw-memorybox, and openclaw-self-evolving, each with repository links and feature descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->