### PR TITLE
feat: add jarvis and jarvis-company-board to plugins list

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ Over 150 production-ready plugins that extend Claude Code with domain-specific c
 | [devops-automator](plugins/devops-automator/) | DevOps automation scripts for CI/CD, health checks, and deployments |
 | [discuss](plugins/discuss/) | Debate implementation approaches with structured pros and cons analysis |
 | [discoclaw](https://github.com/DiscoClaw/discoclaw) | Personal AI orchestrator that bridges Discord to Claude Code with durable memory, task tracking, and cron-based automation |
+| [jarvis](https://github.com/Ramsbaby/jarvis) | Turns an idle Claude Max subscription into a 24/7 AI ops system — Discord bot, 76 scheduled tasks, 12 AI teams, local LanceDB RAG, 98% context compression via Nexus CIG, and 4-layer self-healing infrastructure. Uses `claude -p` headless mode at $0 extra cost. |
+| [jarvis-company-board](https://github.com/Ramsbaby/jarvis-company-board) | Real-time AI agent collaboration board built on Next.js 15 and SQLite WAL — 8 named AI board members debate decisions via SSE push, with a DEV task approval workflow and Railway deploy support. |
 | [dna-claude-analysis](https://github.com/shmlkv/dna-claude-analysis) | Personal genome analysis toolkit that analyzes raw DNA data across 17 categories and generates a terminal-style HTML dashboard |
 | [doc-forge](plugins/doc-forge/) | Documentation generation, API docs, and README maintenance |
 | [docker-helper](plugins/docker-helper/) | Build optimized Docker images and improve Dockerfile best practices |


### PR DESCRIPTION
## Summary

Adds two related Claude Code automation projects to the All Plugins section (alphabetically after `discoclaw`):

- **[jarvis](https://github.com/Ramsbaby/jarvis)** — Turns an idle Claude Max subscription into a 24/7 AI ops system. Discord bot + 76 scheduled tasks + 12 AI teams + local LanceDB RAG + 98% context compression (Nexus CIG) + 4-layer self-healing. Uses `claude -p` headless mode at $0 extra cost on an existing Claude Max subscription.

- **[jarvis-company-board](https://github.com/Ramsbaby/jarvis-company-board)** — Real-time AI agent collaboration board (Next.js 15 + SQLite WAL). 8 named AI board members debate decisions via SSE push, with DEV task approval workflow and Railway deploy support. Serves as the UI layer for jarvis.

Both repos are MIT-licensed, publicly accessible, and have been in active development for several weeks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the All Plugins reference guide with two new plugin entries: `jarvis` and `jarvis-company-board`. Each entry includes direct links to the respective GitHub repositories and detailed feature descriptions to help users understand the capabilities of each plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->