### PR TITLE
Add claude-code-power-stack to plugins list

### DIFF
--- a/README.md
+++ b/README.md
@@ -799,6 +799,8 @@ claude-code-toolkit/               800+ files
 
 ## Ecosystem
 
+| [claude-code-power-stack](https://github.com/bluzername/claude-code-power-stack) | | Curated toolkit bundling Ghost (persistent memory), cc-conversation-search (cross-project session search), session naming, and Manus-style file-based planning into one-command install with cheat sheet PDF |
+
 Notable projects, directories, and resources across the Claude Code ecosystem.
 
 | Name | Stars | Description |


### PR DESCRIPTION
Hey, wanted to add my project claude-code-power-stack here. I build this toolkit that bundles together Ghost memory, conversation search, session naming and Manus-style planning into single install. It also comes with cheat sheet PDF which I think is pretty handy. Hope it can be useful for other people using Claude Code too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new Ecosystem entry for "claude-code-power-stack" with a linked repository and short description.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->