### PR TITLE
feat: add ADHX to Community Skills table

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,6 +485,7 @@ Thirty-five curated skill modules included in this repo, with access to **400,00
 | [claude-skills](https://github.com/alirezarezvani/claude-skills) | `git clone` | 192 production-ready skills across 9 domains (engineering, marketing, product, compliance, C-level advisory) with 254 Python automation tools. 5,300+ stars |
 | [n8n-skills](https://github.com/czlonkowski/n8n-skills) | `git clone` | 7 complementary skills for building production-ready n8n workflows. Covers 525+ nodes, 2,653+ templates. 3,400+ stars |
 | [claude-code-best-practice](https://github.com/shanraisshan/claude-code-best-practice) | `git clone` | Comprehensive reference implementation for Claude Code configuration -- skills, subagents, hooks, commands with practical examples. 17,400+ stars |
+| [ADHX](https://github.com/itsmemeworks/adhx) | `/plugin marketplace add itsmemeworks/adhx` or `curl -sL https://raw.githubusercontent.com/itsmemeworks/adhx/main/skills/adhx/SKILL.md -o ~/.claude/skills/adhx/SKILL.md` | Fetch any X/Twitter post as clean LLM-friendly JSON — no scraping, works with tweets and full X Articles |
 
 ### Installing Skills
 


### PR DESCRIPTION
Adds ADHX (https://adhx.com) to the Community Skills table.

ADHX is an open-source Claude Code skill that fetches any X/Twitter post as clean LLM-friendly JSON. No scraping or browser required. Works with both regular tweets and full X Articles.

Install:
- /plugin marketplace add itsmemeworks/adhx
- curl -sL https://raw.githubusercontent.com/itsmemeworks/adhx/main/skills/adhx/SKILL.md -o ~/.claude/skills/adhx/SKILL.md

Source: https://github.com/itsmemeworks/adhx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented the ADHX community skill for X/Twitter data retrieval. The skill formats posts as clean JSON for use with language models. Installation is available through the Claude Code plugin marketplace or by downloading to the local skills directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->