### PR TITLE
Add claude-code-blueprint to Templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -676,6 +676,9 @@ Fifteen coding rules that enforce consistent patterns. Add to `.claude/rules/` o
 
 ## Templates
 
+- **[claude-code-blueprint](https://github.com/faizkhairi/claude-code-blueprint)** - Battle-tested reference architecture for Claude Code power users. Specialized agents with model tiering, natural-language skills, lifecycle hooks, path-scoped rules, starter presets, benchmarks, battle stories, and cross-tool mapping. Zero dependencies, MIT licensed.
+
+
 Seven CLAUDE.md templates for different project types.
 
 | Template | File | Use Case |


### PR DESCRIPTION
Battle-tested reference architecture for Claude Code power users. Specialized agents with model tiering, natural-language skills, lifecycle hooks, path-scoped rules, starter presets, benchmarks, battle stories, and cross-tool mapping. Zero dependencies, MIT licensed.

https://github.com/faizkhairi/claude-code-blueprint

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new template reference in the Templates section linking to a Claude Code reference architecture with information about agent/system features and licensing details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->