### PR TITLE
Add ultraship — all-in-one builder toolkit plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ Over 150 production-ready plugins that extend Claude Code with domain-specific c
 | [tool-evaluator](plugins/tool-evaluator/) | Evaluate and compare developer tools with structured scoring criteria |
 | [type-migrator](plugins/type-migrator/) | Migrate JavaScript files to TypeScript with proper types |
 | [ui-designer](plugins/ui-designer/) | Implement UI designs from specs with pixel-perfect component generation |
+| [ultraship](https://github.com/Houseofmvps/ultraship) | All-in-one builder toolkit with 22 automatic skills, 20 tools, 5 agents — brainstorming to deployment. Install: `claude plugin add npm:ultraship` |
 | [ultrathink](plugins/ultrathink/) | Deep analysis mode with extended reasoning for complex problems |
 | [unit-test-generator](plugins/unit-test-generator/) | Generate comprehensive unit tests for any function or module |
 | [update-branch](plugins/update-branch/) | Rebase and update feature branches with conflict resolution |


### PR DESCRIPTION
## Summary

Adds **Ultraship** to the All Plugins table.

All-in-one builder plugin for Claude Code with 22 automatic skills, 20 tools, and 5 agents covering the full dev lifecycle: brainstorming, planning, TDD, code review, frontend design, SEO/GEO/AEO audits, Lighthouse performance, security hardening, and deployment.

Skills activate automatically based on context — no manual invocation needed.

## Install

```bash
claude plugin add npm:ultraship
```

## Links

- GitHub: https://github.com/Houseofmvps/ultraship
- npm: https://www.npmjs.com/package/ultraship
- License: MIT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added ultraship plugin entry to the plugins table with repository link, description, and installation instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->