### PR TITLE
Add claude-starter-kit to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -818,6 +818,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [myclaude](https://github.com/stellarlinkco/myclaude) | 2,400+ | Multi-agent orchestration routing to Claude Code, Codex, Gemini, and OpenCode |
 | [claude-code-mcp](https://github.com/steipete/claude-code-mcp) | 1,100+ | Run Claude Code as a one-shot MCP server -- an agent in your agent |
 | [ccmanager](https://github.com/kbwo/ccmanager) | 940+ | Session manager supporting 8 coding agents with smart auto-approval |
+| [claude-starter-kit](https://github.com/awrshift/claude-starter-kit) | new | Ready-to-use project structure with persistent memory, session continuity, hooks, and 3 bundled skills (Gemini, Brainstorm, Design) |
 
 ---
 


### PR DESCRIPTION
## Add claude-starter-kit to Ecosystem section

**Entry:**
| [claude-starter-kit](https://github.com/awrshift/claude-starter-kit) | new | Ready-to-use project structure with persistent memory, session continuity, hooks, and 3 bundled skills (Gemini, Brainstorm, Design) |

### What it includes
- **Memory system** — MEMORY.md + CONTEXT.md + snapshots/ for cross-session persistence
- **Session continuity** — next-session-prompt.md with `<!-- PROJECT:name -->` tags for parallel multi-project work
- **Hooks** — session-start.sh (context injection) + pre-compact.sh (prevents context loss on /compact)
- **3 Bundled skills** — Gemini (second opinions from different model family), Brainstorm (3-round Claude x Gemini dialogue), Design (design token pipeline + VQA)
- **Auto-setup** — agent self-configures on first run, installs global skills, cleans scaffolding
- **Visual docs** — 3 infographics explaining agent anatomy, context layers, session lifecycle

Based on 1000+ sessions of iterative refinement. MIT licensed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated ecosystem documentation to include a new notable project entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->