### PR TITLE
Add claude-code-kickstart to Ecosystem section

### DIFF
--- a/README.md
+++ b/README.md
@@ -818,6 +818,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [myclaude](https://github.com/stellarlinkco/myclaude) | 2,400+ | Multi-agent orchestration routing to Claude Code, Codex, Gemini, and OpenCode |
 | [claude-code-mcp](https://github.com/steipete/claude-code-mcp) | 1,100+ | Run Claude Code as a one-shot MCP server -- an agent in your agent |
 | [ccmanager](https://github.com/kbwo/ccmanager) | 940+ | Session manager supporting 8 coding agents with smart auto-approval |
+| [claude-code-kickstart](https://github.com/ypollak2/claude-code-kickstart) | New | Opinionated starter kit — one command to install curated MCP servers, hooks, agents, and profiles. Includes auto-detect, 12 agents, 10 profiles, and 20+ shell commands |
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds [claude-code-kickstart](https://github.com/ypollak2/claude-code-kickstart) to the Ecosystem section
- Opinionated starter kit — one command to install curated MCP servers, hooks, agents, and profiles
- Includes auto-detect, 12 agents, 10 profiles, and 20+ shell commands

## Why

claude-code-kickstart provides a batteries-included setup experience for Claude Code users, reducing the time from install to productive workflow. It fits naturally in the Ecosystem section alongside other tooling and configuration projects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Added a new ecosystem project entry featuring a starter kit that enables one-command setup of pre-configured development tools, servers, and automation agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->