### PR TITLE
Add AKF — The AI Native File Format

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Over 150 production-ready plugins that extend Claude Code with domain-specific c
 
 | Plugin | Description |
 |--------|-------------|
+| [AKF — The AI Native File Format](https://github.com/HMAKT99/AKF) | EXIF for AI. Stamps every file with trust scores, source provenance, and compliance metadata. Embeds into 20+ formats. MCP server (9 tools), shell hook, EU AI Act auditing. [akf.dev](https://akf.dev) |
 | [aws-cost-saver](https://github.com/prajapatimehul/aws-cost-saver) | AWS cost optimization scanner with 173 automated checks, ML-powered rightsizing, and Zero Hallucination Pricing - Real result: 60% cost reduction |
 | [claude-code-mcp](https://github.com/steipete/claude-code-mcp) | Run Claude Code as a one-shot MCP server -- an agent in your agent. Permissions bypassed automatically. By Peter Steinberger. 1,100+ stars |
 | [claude-code-system-prompts](https://github.com/Piebald-AI/claude-code-system-prompts) | Extracted system prompts from Claude Code -- 18 builtin tool descriptions, sub-agent prompts, utility prompts. Updated for each release. 5,900+ stars |


### PR DESCRIPTION
AKF is the AI native file format — EXIF for AI. Stamps every file with trust scores, source provenance, and compliance metadata (~15 tokens of JSON).

- Embeds into 20+ formats (DOCX, PDF, images, code)
- MCP server with 9 tools
- Shell hook auto-stamps AI outputs
- EU AI Act, SOX, HIPAA compliance
- `pip install akf` | https://akf.dev

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new plugin entry to the "All Plugins" table in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->