### PR TITLE
Add The Pragmatic PM — PM leadership toolkit plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Over 150 production-ready plugins that extend Claude Code with domain-specific c
 | [smart-commit](plugins/smart-commit/) | Intelligent git commits with conventional format, semantic analysis, and changelog generation |
 | [sprint-prioritizer](plugins/sprint-prioritizer/) | Sprint planning with story prioritization and capacity estimation |
 | [technical-sales](plugins/technical-sales/) | Technical demo creation and POC proposal writing |
+| [the-pragmatic-pm](https://github.com/marfoerst/the-pragmatic-pm) | PM leadership toolkit with 43 skills, 5 agents, 4 workflows. Covers PRD generation, OKR lifecycle, pricing, AI pricing, positioning, sales enablement, and quarterly planning. |
 | [terraform-helper](plugins/terraform-helper/) | Terraform module creation and infrastructure planning |
 | [test-data-generator](plugins/test-data-generator/) | Generate realistic test data and seed databases |
 | [test-results-analyzer](plugins/test-results-analyzer/) | Analyze test failures, identify patterns, and suggest targeted fixes |


### PR DESCRIPTION
## Summary

- Adds [The Pragmatic PM](https://github.com/marfoerst/the-pragmatic-pm) to the All Plugins table
- PM leadership toolkit with 43 skills, 5 orchestrator agents, 4 multi-stage workflows, and 4 automation hooks
- Covers PRD generation, OKR lifecycle, pricing, AI pricing, positioning, sales enablement, and quarterly planning
- Built on proven PM frameworks: April Dunford (positioning), Simon-Kucher (pricing), Teresa Torres (discovery), John Doerr (OKRs)

## Install

```
/plugin install pm-toolkit@the-pragmatic-pm
```

## Plugin highlights

- **43 standalone skills** across 7 categories (Foundation, Discovery & Data, Strategy, Communication, Go-to-Market, Operations, Workflows)
- **5 orchestrator agents** that route user intent to the right skill
- **4 multi-stage workflows** with checkpoint-driven artifact chains
- **4 hooks** for context reinjection, quality gating, usage logging, and workflow tracking
- Domain-agnostic via `domain-context.md` + `personal-context.md`
- MIT licensed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new plugin entry to the available plugins for a PM leadership toolkit with specified skills, agents, and workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->