### PR TITLE
Add CoinPaprika & DexPaprika to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -485,6 +485,7 @@ Thirty-five curated skill modules included in this repo, with access to **400,00
 | [claude-skills](https://github.com/alirezarezvani/claude-skills) | `git clone` | 192 production-ready skills across 9 domains (engineering, marketing, product, compliance, C-level advisory) with 254 Python automation tools. 5,300+ stars |
 | [n8n-skills](https://github.com/czlonkowski/n8n-skills) | `git clone` | 7 complementary skills for building production-ready n8n workflows. Covers 525+ nodes, 2,653+ templates. 3,400+ stars |
 | [claude-code-best-practice](https://github.com/shanraisshan/claude-code-best-practice) | `git clone` | Comprehensive reference implementation for Claude Code configuration -- skills, subagents, hooks, commands with practical examples. 17,400+ stars |
+| [CoinPaprika & DexPaprika Skills](https://github.com/coinpaprika/skills) | `npx skills add github.com/coinpaprika/skills` | Two crypto data skills: CoinPaprika (12K+ coins, 350+ exchanges, OHLCV) and DexPaprika (34 chains, 30M+ DEX pools, real-time SSE streaming). Free, no API key |
 
 ### Installing Skills
 


### PR DESCRIPTION
Adds CoinPaprika & DexPaprika crypto data skills to the Community Skills table.

Two skills from one repo: CoinPaprika (12K+ coins, 350+ exchanges, OHLCV) and DexPaprika (34 chains, 30M+ DEX pools, real-time SSE streaming). Free, no API key. Install: `npx skills add github.com/coinpaprika/skills`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added CoinPaprika & DexPaprika Skills community integration to the Community Skills table. This new skill enables real-time cryptocurrency market data streaming and decentralized exchange information access. Installation is straightforward with no API key, account registration, or subscription fees required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->