### PR TITLE
Add cog to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -833,6 +833,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [myclaude](https://github.com/stellarlinkco/myclaude) | 2,400+ | Multi-agent orchestration routing to Claude Code, Codex, Gemini, and OpenCode |
 | [claude-code-mcp](https://github.com/steipete/claude-code-mcp) | 1,100+ | Run Claude Code as a one-shot MCP server -- an agent in your agent |
 | [ccmanager](https://github.com/kbwo/ccmanager) | 940+ | Session manager supporting 8 coding agents with smart auto-approval |
+| [cog](https://github.com/marciopuga/cog) | 240+ | Cognitive architecture for Claude Code -- persistent memory, self-reflection, and foresight via plain-text conventions. Zero dependencies, just CLAUDE.md + markdown files |
 | [Cortex](https://github.com/SKULLFIRE07/cortex-memory) | -- | Persistent AI memory for coding assistants. Auto-captures decisions, patterns, and context across sessions. VSCode extension + CLI + MCP server. Free |
 | [openclaw-self-healing](https://github.com/Ramsbaby/openclaw-self-healing) | 32+ | 4-tier autonomous crash recovery for Claude Code and any service — 64% auto-resolved, LLM-agnostic (Claude/GPT-4/Gemini/Ollama), Prometheus metrics |
 | [openclaw-memorybox](https://github.com/Ramsbaby/openclaw-memorybox) | 8+ | Memory hygiene CLI for Claude Code — prevents context overflow crashes, 83% MEMORY.md size reduction, zero dependencies |


### PR DESCRIPTION
## Summary

- Adds [cog](https://github.com/marciopuga/cog) to the Ecosystem table
- Cognitive architecture for Claude Code — persistent memory, self-reflection, and foresight using only plain-text conventions (CLAUDE.md + markdown files)
- Zero dependencies, MIT licensed

## Summary by CodeRabbit

* **Documentation**
  * Added a new project entry to the ecosystem section of the README, highlighting a notable project with cognitive-architecture features including persistent memory, self-reflection, and foresight capabilities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)