### PR TITLE
Add AIRIS MCP Gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -841,6 +841,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [claude-code-kickstart](https://github.com/ypollak2/claude-code-kickstart) | New | Opinionated starter kit — one command to install curated MCP servers, hooks, agents, and profiles. Includes auto-detect, 12 agents, 10 profiles, and 20+ shell commands |
 | [claude-code-power-stack](https://github.com/bluzername/claude-code-power-stack) | new | Ghost memory, conversation search, session naming, and Manus-style planning in a single install with cheat sheet PDF |
 | [clooks](https://github.com/mauribadnights/clooks) | new | Persistent hook daemon that replaces per-invocation spawning -- 112x faster hooks with batching, dependency resolution, metrics |
+| [AIRIS MCP Gateway](https://github.com/agiletec-inc/airis-mcp-gateway) | new | Docker-based MCP multiplexer that aggregates 60+ tools behind 7 meta-tools, reducing context token usage by 97%. One command to start, auto-enables servers on demand |
 | [gemini-claude-bridge](https://github.com/weijiafu14/gemini-claude-bridge) | new | Gemini-to-Claude protocol converter for using Gemini models as Claude Code backend. Fixes 3 LiteLLM bugs |
 
 ---


### PR DESCRIPTION
## Summary

- Adds [AIRIS MCP Gateway](https://github.com/agiletec-inc/airis-mcp-gateway) to the Ecosystem section
- Docker-based MCP multiplexer that aggregates 60+ tools behind 7 meta-tools, reducing context token usage by 97%
- One command to start, auto-enables servers on demand via lazy loading and idle-kill

## Details

AIRIS MCP Gateway is a FastAPI-based MCP multiplexer that sits between Claude Code and 60+ MCP servers. Instead of exposing all tools directly (42k+ tokens), it exposes 7 meta-tools (~600 tokens) that dynamically discover, schema-check, and execute any tool on demand. Servers are lazy-started on first use and auto-killed after idle timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the ecosystem section to include AIRIS MCP Gateway as a notable project and resource.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->