### PR TITLE
Add Spartan AI Toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -842,7 +842,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [claude-code-power-stack](https://github.com/bluzername/claude-code-power-stack) | new | Ghost memory, conversation search, session naming, and Manus-style planning in a single install with cheat sheet PDF |
 | [clooks](https://github.com/mauribadnights/clooks) | new | Persistent hook daemon that replaces per-invocation spawning -- 112x faster hooks with batching, dependency resolution, metrics |
 | [gemini-claude-bridge](https://github.com/weijiafu14/gemini-claude-bridge) | new | Gemini-to-Claude protocol converter for using Gemini models as Claude Code backend. Fixes 3 LiteLLM bugs |
-| [spartan-ai-toolkit](https://github.com/spartan-stratos/spartan-ai-toolkit) | new | Engineering discipline layer for Claude Code -- 56 slash commands, 12 coding rules, 22 skills, 7 agents, quality gates between every step. 8 stack profiles (Go, Python, Java, Kotlin, React, etc.), agent memory across sessions. Install: `npx @c0x12c/spartan-ai-toolkit@latest --local` |
+| [spartan-ai-toolkit](https://github.com/spartan-stratos/spartan-ai-toolkit) | new | Engineering discipline layer for Claude Code -- 67 slash commands, 20 coding rules, 27 skills, 9 agents, quality gates between every step. 8 stack profiles (Go, Python, Java, Kotlin, React, etc.), agent memory across sessions. Install: `npx @c0x12c/spartan-ai-toolkit@latest --local` |
 
 ---
 


### PR DESCRIPTION
Adding Spartan AI Toolkit to the Ecosystem section.

- 56 slash commands, 12 coding rules, 22 skills, 7 agents
- Quality gates between every pipeline step
- 8 stack profiles (Go, Python, Java, Kotlin, React, etc.)
- Agent memory across sessions
- Install: `npx @c0x12c/spartan-ai-toolkit@latest --local`

https://github.com/spartan-stratos/spartan-ai-toolkit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new ecosystem entry for spartan-ai-toolkit with a "new" status, repository reference, and a concise description of features (slash-commands, rules/skills/agents, quality gates, stack profiles, cross-session agent memory).
  * Included installation command: npx @c0x12c/spartan-ai-toolkit@latest --local
<!-- end of auto-generated comment: release notes by coderabbit.ai -->