### PR TITLE
feat: add crit to Companion Apps & GUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -809,6 +809,7 @@ claude-code-toolkit/               800+ files
 | [Claw](https://github.com/jamesrochabrun/Claw) | 86 | Native macOS app wrapping Claude Code SDK in Swift. Plan Mode, MCP Integration, Custom System Prompts |
 | [The Claude Protocol](https://github.com/AvivK5498/The-Claude-Protocol) | 149 | Enforcement layer wrapping Claude Code with 13 hooks -- blocks unsafe operations, enforces worktree isolation |
 | [Notch So Good](https://github.com/deepshal99/notch-so-good) | new | macOS notch-based session monitor with pixel-art companion, 13 animations, smart notifications, multi-session support |
+| [crit](https://github.com/tomasz-tomczyk/crit) | 105 | Local browser UI for inline code review of any file or agent output; integrates with Claude Code via plan-hook to review and approve plans before execution, outputs structured .crit.json for agent consumption. |
 
 ---
 


### PR DESCRIPTION
## Summary
- Adds crit (https://github.com/tomasz-tomczyk/crit) to the Companion Apps & GUIs table
- Local Go CLI that serves a browser UI for inline code review -- run `crit` to review any file or agent output with GitHub-style inline comments
- Integrates with Claude Code via plan-hook (PermissionRequest hook) -- Claude proposes a plan, you review it in crit's browser before execution
- Outputs structured .crit.json that agents read as data
- Single binary, offline, 105 stars, MIT

## Install

```bash
brew install tomasz-tomczyk/tap/crit
```

```
/plugin marketplace add tomasz-tomczyk/crit
/plugin install crit
```