### PR TITLE
Add ultraship to All Plugins table

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Over 150 production-ready plugins that extend Claude Code with domain-specific c
 | [type-migrator](plugins/type-migrator/) | Migrate JavaScript files to TypeScript with proper types |
 | [ui-designer](plugins/ui-designer/) | Implement UI designs from specs with pixel-perfect component generation |
 | [ultrathink](plugins/ultrathink/) | Deep analysis mode with extended reasoning for complex problems |
-| [ultraship](https://github.com/Houseofmvps/ultraship) | Pre-deploy auditing (SEO, security, code profiling, bundle size), structured workflows (TDD, code review, planning), and project tooling (architecture mapping, incident response, competitive analysis). 29 Node.js tools, 1 dependency. |
+| [ultraship](https://github.com/Houseofmvps/ultraship) | 32 expert-level skills for building, shipping, and scaling production software. 29 audit tools (security, code quality, bundle size, SEO/GEO/AEO) close the loop before deploy. 1 dependency. |
 | [unit-test-generator](plugins/unit-test-generator/) | Generate comprehensive unit tests for any function or module |
 | [update-branch](plugins/update-branch/) | Rebase and update feature branches with conflict resolution |
 | [vision-specialist](plugins/vision-specialist/) | Image and visual analysis with screenshot interpretation and text extraction |


### PR DESCRIPTION
Adds [ultraship](https://github.com/Houseofmvps/ultraship) to the All Plugins table (alphabetical, between ultrathink and unit-test-generator).

**What it is:** A Claude Code plugin with 32 expert-level skills for building, shipping, and scaling production software. 29 audit tools close the loop before deploy.

**Builder skills:** TDD enforcement, code review with confidence scoring, structured planning, deploy pipeline with rollback plans, frontend design, API design, data modeling, debugging, refactoring

**Audit tools:** Secret scanner, code profiler (N+1 queries, sync I/O, memory leaks), bundle tracker, dependency doctor (import graph analysis), SEO/GEO/AEO scanner (60+ rules)

**Project tools:** Architecture mapper (Mermaid diagrams), incident commander (git culprit analysis + rollback), competitive analyzer, growth tracker, onboard generator

**Technical details:**
- 1 dependency (`htmlparser2`, 30KB)
- 113 unit tests
- All tools use `execFileSync` (no shell injection)
- SSRF protection on all HTTP tools
- MIT licensed

```bash
claude plugin marketplace add Houseofmvps/ultraship
claude plugin install ultraship
```

npm: https://www.npmjs.com/package/ultraship

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an ultraship plugin entry to the Plugins table linking to its external repository. Describes expert-level capabilities (32 skills), pre-deploy auditing (29 audit tools across security, code quality, bundle-size, SEO/GEO/AEO), dependency info, and structured support for code review, planning, architecture mapping, incident response, profiling, and competitive analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->