### PR TITLE
Add The CLAUDE.md Bible to Templates section

### DIFF
--- a/README.md
+++ b/README.md
@@ -687,7 +687,8 @@ Fifteen coding rules that enforce consistent patterns. Add to `.claude/rules/` o
 
 ## Templates
 
-- **[claude-code-blueprint](https://github.com/faizkhairi/claude-code-blueprint)** - Battle-tested reference architecture for Claude Code power users. Specialized agents with model tiering, natural-language skills, lifecycle hooks, path-scoped rules, starter presets, benchmarks, battle stories, and cross-tool mapping. Zero dependencies, MIT licensed.
+- **[claude-code-blueprint](https://github.com/faizkhairi/claude-code-blueprint)** - Battle-tested reference architecture for Claude Code power users. Specialized agents with model hhtiering, natural-language skills, lifecycle hooks, path-scoped rules, starter presets, benchmarks, battle stories, and cross-tool mapping. Zero dependencies, MIT licensed.
+- **[The CLAUDE.md Bible](https://echochime3.gumroad.com/l/claudemd-bible)** - 25 stack-specific CLAUDE.md configs covering React, Next.js, FastAPI, Django, Svelte, Chrome Extensions, CLI tools, MCP servers, and more. Each config is 80-150 lines of tested rules for the specific patterns and pitfalls of each stack, plus a masterclass guide.
 
 
 Seven CLAUDE.md templates for different project types.


### PR DESCRIPTION
Adds The CLAUDE.md Bible to the Templates section. It's a collection of 25 stack-specific CLAUDE.md configs covering frontend (React, Next.js, Svelte, Vue, Astro), backend (FastAPI, Express, Django, Flask), fullstack, and specialized stacks (Chrome Extensions, CLI tools, MCP servers). Each config is 80-150 lines of tested rules and patterns, plus a masterclass guide on writing effective configs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated template description text for improved clarity
  * Added new reference to "The CLAUDE.md Bible" resource, providing 25 stack-specific configurations and a masterclass guide

<!-- end of auto-generated comment: release notes by coderabbit.ai -->