### PR TITLE
Add Claude Code Cheat Sheet to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -842,7 +842,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [claude-code-power-stack](https://github.com/bluzername/claude-code-power-stack) | new | Ghost memory, conversation search, session naming, and Manus-style planning in a single install with cheat sheet PDF |
 | [clooks](https://github.com/mauribadnights/clooks) | new | Persistent hook daemon that replaces per-invocation spawning -- 112x faster hooks with batching, dependency resolution, metrics |
 | [gemini-claude-bridge](https://github.com/weijiafu14/gemini-claude-bridge) | new | Gemini-to-Claude protocol converter for using Gemini models as Claude Code backend. Fixes 3 LiteLLM bugs |
-| [claude-code-cheat-sheet](https://cc.storyfox.cz/) | new | Complete one-page printable reference — all shortcuts, commands, CLI flags, MCP config, memory, skills, agents. Auto-updated daily from official docs. EN, ZH, JA, KO |
+| [claude-code-cheat-sheet](https://cc.storyfox.cz/) | new | Complete one-page printable reference — all shortcuts, commands, CLI flags, MCP config, memory, skills, agents. Auto-updated daily from official docs. [EN](https://cc.storyfox.cz/) · [ZH](https://cc.storyfox.cz/zh/) · [JA](https://cc.storyfox.cz/jp/) · [KO](https://cc.storyfox.cz/kr/) |
 
 ---
 


### PR DESCRIPTION
Adding [Claude Code Cheat Sheet](https://cc.storyfox.cz/) to the Ecosystem section.

- One-page printable reference with all shortcuts, commands, CLI flags, MCP config, memory, skills, and agents
- Auto-updated daily from official docs
- Available in 4 languages: [EN](https://cc.storyfox.cz/), [ZH](https://cc.storyfox.cz/zh/), [JA](https://cc.storyfox.cz/jp/), [KO](https://cc.storyfox.cz/kr/)
- Hit HN frontpage with 130k+ pageviews

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added the `claude-code-cheat-sheet` entry to the Ecosystem reference. Provides a comprehensive, one-page printable guide covering shortcuts, commands, CLI flags, MCP configuration, memory, skills, and agents. The resource is auto-updated daily from official docs and includes language-specific versions (EN, ZH, JA, KO) for convenient quick-reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->