### PR TITLE
Add Bernstein to Companion Apps & GUIs – parallel multi-agent orchestrator

### DIFF
--- a/README.md
+++ b/README.md
@@ -804,6 +804,7 @@ claude-code-toolkit/               800+ files
 | [Claude-Code-Workflow](https://github.com/catlog22/Claude-Code-Workflow) | 1,400+ | JSON-driven multi-agent cadence-team framework with intelligent CLI orchestration (Gemini/Qwen/Codex) |
 | [ccswarm](https://github.com/nwiizo/ccswarm) | 127 | Rust-based multi-agent orchestration with specialized agent pools, Git worktree isolation, 93% token reduction |
 | [parallel-code](https://github.com/johannesjo/parallel-code) | 370+ | Run Claude Code, Codex, and Gemini side by side -- each in its own git worktree |
+| [Bernstein](https://github.com/chernistry/bernstein) | 5+ | Python multi-agent orchestrator — spawns Claude Code, Codex CLI, and Gemini CLI in parallel on isolated git worktrees, verifies with tests, auto-commits. Zero LLM tokens on coordination |
 | [Poirot](https://github.com/LeonardoCardoso/Poirot) | 96 | macOS app for browsing Claude Code sessions, viewing diffs, and re-running commands. Reads local transcripts, runs offline |
 | [TokenEater](https://github.com/AThevon/TokenEater) | 179 | Native macOS menu bar app for monitoring Claude AI usage limits and watching coding sessions live |
 | [Claw](https://github.com/jamesrochabrun/Claw) | 86 | Native macOS app wrapping Claude Code SDK in Swift. Plan Mode, MCP Integration, Custom System Prompts |


### PR DESCRIPTION
Bernstein is an open-source Python orchestrator (Apache 2.0) that spawns Claude Code, Codex CLI, and Gemini CLI in parallel on isolated git worktrees. A deterministic scheduler — zero LLM tokens on coordination — verifies every result with your test suite and commits only what passes. Similar in spirit to parallel-code and ccswarm already listed. GitHub: https://github.com/chernistry/bernstein

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Bernstein to the list of companion apps and GUIs—a Python multi-agent orchestrator that runs Claude, Code, Codex, and Gemini CLI in parallel on isolated git worktrees with validation and auto-commit functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->