### PR TITLE
Add claude-rank — SEO/GEO/AEO audit plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Over 150 production-ready plugins that extend Claude Code with domain-specific c
 | [claude-mem](https://github.com/thedotmack/claude-mem) | Automatically captures everything Claude does, compresses with AI, injects relevant context into future sessions. SQLite + full-text search. 35,900+ stars |
 | [claude-notifications-go](https://github.com/777genius/claude-notifications-go) | Cross-platform smart notifications -- 6 types, click-to-focus, context analysis, webhooks. Single Go binary, zero deps. 340+ stars |
 | [claude-recap](https://github.com/hatawong/claude-recap) | Per-topic session memory using Shell hooks — archives each conversation topic as a separate Markdown summary. Two hooks, bash + Node.js, 100% local |
+| [claude-rank](https://github.com/Houseofmvps/claude-rank) | SEO/GEO/AEO audit plugin — tells you why AI won't cite your site, then auto-fixes robots.txt, sitemap.xml, llms.txt, and JSON-LD. 170+ rules across 10 scanners, zero config |
 | [claude-sounds](https://github.com/culminationAI/claude-sounds) | Audio feedback for Claude Code hooks — 10 events, 21 sounds, random rotation. macOS (`afplay`). |
 | [claude-supermemory](https://github.com/supermemoryai/claude-supermemory) | Persistent memory across sessions and projects using Supermemory. User profile injection at session start, automatic conversation capture. 2,300+ stars |
 | [code-architect](plugins/code-architect/) | Generate architecture diagrams and technical design documents |


### PR DESCRIPTION
## What is claude-rank?

A Claude Code plugin that tells you why your site won't get cited by AI — and fixes the discoverability files automatically.

- **170+ rules** across **10 scanners**: SEO, GEO, AEO, AI Citability, Content, Keywords, Performance + Mobile, Vertical SEO, Security, Content Brief
- **Auto-fix**: generates corrected robots.txt, sitemap.xml, llms.txt, and JSON-LD
- **URL + directory scanning**: audit any site without downloading it
- **Zero config**: single dependency (htmlparser2), works out of the box
- **Free and open source** (MIT)

**GitHub**: https://github.com/Houseofmvps/claude-rank
**npm**: https://www.npmjs.com/package/@houseofmvps/claude-rank

## Install

```
/install-plugin Houseofmvps/claude-rank
```

Or via npm:
```
npm i -g @houseofmvps/claude-rank
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation with a new plugin entry featuring SEO/GEO/AEO auditing and automated fixing capabilities, including support for robots.txt, sitemap.xml, llms.txt, and JSON-LD, with zero configuration required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->