### PR TITLE
Add skill: SkillNav

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,6 +495,7 @@ Thirty-five curated skill modules included in this repo, with access to **400,00
 | [n8n-skills](https://github.com/czlonkowski/n8n-skills) | `git clone` | 7 complementary skills for building production-ready n8n workflows. Covers 525+ nodes, 2,653+ templates. 3,400+ stars |
 | [claude-code-best-practice](https://github.com/shanraisshan/claude-code-best-practice) | `git clone` | Comprehensive reference implementation for Claude Code configuration -- skills, subagents, hooks, commands with practical examples. 17,400+ stars |
 | [ADHX](https://github.com/itsmemeworks/adhx) | `/plugin marketplace add itsmemeworks/adhx` or `curl -sL https://raw.githubusercontent.com/itsmemeworks/adhx/main/skills/adhx/SKILL.md -o ~/.claude/skills/adhx/SKILL.md` | Fetch any X/Twitter post as clean LLM-friendly JSON — no scraping, works with tweets and full X Articles |
+| [SkillNav](https://github.com/skillnav-dev/skillnav-skill) | `clawhub install HuiW86/skillnav` | Search 3,900+ MCP servers with install commands, get daily AI brief, query arXiv papers, and discover trending tools -- all in Chinese. Curated by skillnav.dev editorial team |
 
 ### Installing Skills
 


### PR DESCRIPTION
## What

Adds [SkillNav](https://github.com/skillnav-dev/skillnav-skill) to the Community Skills table.

## About SkillNav

SkillNav is a Claude Code skill for Chinese AI developers. It provides:

- **MCP search** — search 3,900+ MCP servers with ready-to-use install commands
- **Daily AI brief** — editorially curated daily news digest
- **Paper query** — arXiv paper lookup with Chinese summaries
- **Trending tools** — weekly trending skills and MCP servers
- **Unified search** — cross-search articles, tools, and concepts

All content is in Chinese, curated by the [skillnav.dev](https://skillnav.dev) editorial team.

## Links

- GitHub: https://github.com/skillnav-dev/skillnav-skill
- ClawHub: https://clawhub.ai/HuiW86/skillnav
- Website: https://skillnav.dev
- Install: `clawhub install HuiW86/skillnav`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added SkillNav to the Community Skills table with GitHub repository link and installation command, enabling users to discover this community-contributed tool and its features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->