### PR TITLE
Add KANBAII to Companion Apps & GUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -809,6 +809,7 @@ claude-code-toolkit/               800+ files
 | [Claw](https://github.com/jamesrochabrun/Claw) | 86 | Native macOS app wrapping Claude Code SDK in Swift. Plan Mode, MCP Integration, Custom System Prompts |
 | [The Claude Protocol](https://github.com/AvivK5498/The-Claude-Protocol) | 149 | Enforcement layer wrapping Claude Code with 13 hooks -- blocks unsafe operations, enforces worktree isolation |
 | [Notch So Good](https://github.com/deepshal99/notch-so-good) | new | macOS notch-based session monitor with pixel-art companion, 13 animations, smart notifications, multi-session support |
+| [KANBAII](https://github.com/martinmsaavedra/kanbaii) | new | AI-native kanban board for Claude Code — plan visually, track progress, let AI execute. Sequential engine (Ralph), parallel multi-agent (Teams), cost tracking, real-time dashboard. `npx kanbaii start` |
 
 ---
 


### PR DESCRIPTION
## Summary

Adds [KANBAII](https://github.com/martinmsaavedra/kanbaii) to the **Companion Apps & GUIs** section.

**KANBAII** is an AI-native kanban board built for Claude Code:
- **Plan visually** — drag-and-drop kanban with task decomposition
- **Track progress** — real-time dashboard with cost tracking
- **Let AI execute** — Ralph (sequential engine) and Teams (parallel multi-agent) run tasks autonomously
- **Zero config** — `npx kanbaii start`

Published on npm as `kanbaii`.

## Checklist
- [x] Entry follows existing table format
- [x] Added to the correct section (Companion Apps & GUIs)
- [x] Description is concise and factual
- [x] Link points to a public GitHub repository

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added KANBAII to the list of companion apps and GUIs with installation and usage instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->