### PR TITLE
Add agent-dotfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -880,7 +880,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [AIRIS MCP Gateway](https://github.com/agiletec-inc/airis-mcp-gateway) | new | Docker-based MCP multiplexer that aggregates 60+ tools behind 7 meta-tools, reducing context token usage by 97%. One command to start, auto-enables servers on demand |
 | [gemini-claude-bridge](https://github.com/weijiafu14/gemini-claude-bridge) | new | Gemini-to-Claude protocol converter for using Gemini models as Claude Code backend. Fixes 3 LiteLLM bugs |
 | [spartan-ai-toolkit](https://github.com/spartan-stratos/spartan-ai-toolkit) | new | Engineering discipline layer for Claude Code -- 67 slash commands, 20 coding rules, 27 skills, 9 agents, quality gates between every step. 8 stack profiles (Go, Python, Java, Kotlin, React, etc.), agent memory across sessions. Install: `npx @c0x12c/spartan-ai-toolkit@latest --local` |
-| [agent-dotfiles](https://github.com/saqibameen/agent-dotfiles) | new | Write AI coding rules once, sync to every agent. Supports Claude Code, Cursor, Copilot, Codex, OpenCode, Windsurf, Gemini CLI, Kilo Code |
+| [agent-dotfiles](https://github.com/saqibameen/agent-dotfiles) | new | Write AI coding rules once, sync to every agent. Supports Command Code, Claude Code, Cursor, Copilot, Codex, OpenCode. |
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds [agent-dotfiles](https://github.com/saqibameen/agent-dotfiles) to the Ecosystem table in the README.

agent-dotfiles lets you write AI coding rules in one place and sync them to every coding agent. It fits the Ecosystem section alongside other cross-agent config tools like caliber and myclaude.

## Test plan

- [ ] Verify the new table row renders correctly in the README
- [ ] Confirm the link resolves to the correct repository

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an "agent-dotfiles" entry to the Ecosystem table (marked "new"), listing supported agent and IDE environments such as Command Code, Claude Code, Cursor, Copilot, Codex, and OpenCode. This update appears as a single new line in the README's Ecosystem listing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->