### PR TITLE
Add ToolRouter — 150+ tools for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -966,6 +966,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [serena](https://github.com/oraios/serena) | 22,200+ | Semantic retrieval and editing MCP server for coding agents -- code-aware search and navigation |
 | [Understand-Anything](https://github.com/Lum1104/Understand-Anything) | 7,000+ | Turns any codebase into an interactive knowledge graph for exploration |
 | [n8n-mcp](https://github.com/czlonkowski/n8n-mcp) | 17,000+ | MCP for Claude Code to build and manage n8n automation workflows |
+| [ToolRouter](https://toolrouter.com) | -- | Give Claude Code superpowers -- 150+ tools on demand with one account. Competitor research, video production, web search, image generation, security scanning, and more. `claude mcp add toolrouter -- npx -y toolrouter-mcp` |
 
 ---
 


### PR DESCRIPTION
Adds ToolRouter MCP — give Claude Code access to 150+ tools on demand with one account. One API key replaces managing dozens of provider accounts.

- Website: https://toolrouter.com
- npm: https://www.npmjs.com/package/toolrouter-mcp
- Setup: `claude mcp add toolrouter -- npx -y toolrouter-mcp`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added ToolRouter entry to the ecosystem table, providing configuration instructions and access to 150+ tools on demand.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->