### PR TITLE
Add Claudoscope to Companion Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -966,6 +966,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [serena](https://github.com/oraios/serena) | 22,200+ | Semantic retrieval and editing MCP server for coding agents -- code-aware search and navigation |
 | [Understand-Anything](https://github.com/Lum1104/Understand-Anything) | 7,000+ | Turns any codebase into an interactive knowledge graph for exploration |
 | [n8n-mcp](https://github.com/czlonkowski/n8n-mcp) | 17,000+ | MCP for Claude Code to build and manage n8n automation workflows |
+| [Claudoscope](https://github.com/cordwainersmith/claudoscope) | 29 | Native macOS menu bar app for Claude Code session analytics. Token/cost tracking, full-text search, real-time secret detection, config health linting (44 rules). Reads local JSONL files, fully offline, zero telemetry. Swift/SwiftUI, Homebrew install |
 
 ---
 


### PR DESCRIPTION
## What is Claudoscope?

[Claudoscope](https://github.com/cordwainersmith/claudoscope) is a free, open-source native macOS menu bar app that provides observability into Claude Code sessions.

### Key features:
- Reads local JSONL session files from `~/.claude/projects/`
- Session history browsing with full-text search
- Token and cost analytics with model breakdown
- Real-time secret detection in session logs
- Config Health linting (44 rules across 4 categories)
- Surfaces memory, plugins, skills, hooks, and settings
- Built with Swift/SwiftUI, distributed via Homebrew cask
- Completely offline, zero API calls, no telemetry

### Install:
```bash
brew tap cordwainersmith/tap
brew install --cask claudoscope
```

### Links:
- GitHub: https://github.com/cordwainersmith/claudoscope
- Website: https://claudoscope.com/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Claudoscope to the ecosystem directory—a native macOS menu bar application for Claude Code session analytics, featuring token/cost tracking, full-text search, real-time secret detection, and offline JSONL-based processing with zero telemetry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->