### PR TITLE
Add TemplateClaw to Templates section

### DIFF
--- a/README.md
+++ b/README.md
@@ -766,6 +766,7 @@ Fifteen coding rules that enforce consistent patterns. Add to `.claude/rules/` o
 
 - **[claude-code-blueprint](https://github.com/faizkhairi/claude-code-blueprint)** - Battle-tested reference architecture for Claude Code power users. Specialized agents with model hhtiering, natural-language skills, lifecycle hooks, path-scoped rules, starter presets, benchmarks, battle stories, and cross-tool mapping. Zero dependencies, MIT licensed.
 - **[The CLAUDE.md Bible](https://echochime3.gumroad.com/l/claudemd-bible)** - 25 stack-specific CLAUDE.md configs covering React, Next.js, FastAPI, Django, Svelte, Chrome Extensions, CLI tools, MCP servers, and more. Each config is 80-150 lines of tested rules for the specific patterns and pitfalls of each stack, plus a masterclass guide.
+- **[TemplateClaw](https://github.com/jeromwolf/templateclaw)** - Developer template hub and project scaffolding tool packaged as a Claude Code Plugin. 32 production-ready templates across 6 categories (Landing Pages, Dashboards, UI Components, Dev Methodology, Project Setup, Refactoring). 7 slash commands including `/templateclaw`, `/templateclaw-landing`, `/templateclaw-dashboard`, `/templateclaw-ui`. Compatible with Claude Code, Codex, Gemini CLI, and Cursor. MIT licensed.
 
 
 Seven CLAUDE.md templates for different project types.


### PR DESCRIPTION
## Add TemplateClaw

[TemplateClaw](https://github.com/jeromwolf/templateclaw) is a developer template hub packaged as a Claude Code Plugin.

### Features
- **32 production-ready templates** across 6 categories
- **7 slash commands**: `/templateclaw`, `/templateclaw-landing`, `/templateclaw-dashboard`, `/templateclaw-ui`, `/templateclaw-setup`, `/templateclaw-dev`, `/templateclaw-refactor`
- **Categories**: Landing Pages, Dashboards, UI Components, Dev Methodology, Project Setup, Refactoring
- **Multi-platform**: Compatible with Claude Code, Codex, Gemini CLI, and Cursor (Agent Skills open standard)
- **MIT Licensed**

### Install
```
/plugin marketplace add jeromwolf/templateclaw
```

### Links
- GitHub: https://github.com/jeromwolf/templateclaw
- Site: https://jeromwolf.github.io/templateclaw/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added information about a new Claude Code Plugin template hub resource to the documentation, featuring multiple templates, categories, and available commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->