### PR TITLE
Add github-optimization-skill and humanise-text-skill to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,6 +556,8 @@ Thirty-five curated skill modules included in this repo, with access to **400,00
 | [Markdown to EPUB](https://github.com/smerchek/claude-epub-skill) | `git clone` | Convert markdown files into EPUB ebooks |
 | [CSV Data Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) | `git clone` | Generate insights and summaries from CSV data files |
 | [tapestry](https://github.com/michalparkola/tapestry-skills-for-claude-code) | `git clone` | Knowledge networks, iterative learning, article extraction, and YouTube transcript processing |
+| [github-optimization-skill](https://github.com/199-biotechnologies/github-optimization-skill) | `git clone https://github.com/199-biotechnologies/github-optimization-skill ~/.claude/skills/github-optimization` | Turn any GitHub repo into a star-magnet landing page. README optimization, SEO, and repo marketing |
+| [humanise-text-skill](https://github.com/199-biotechnologies/humanise-text-skill) | `git clone https://github.com/199-biotechnologies/humanise-text-skill ~/.claude/skills/humanise-text` | Strip AI writing patterns from any text. 507-entry banned word list, structural pattern detection, and 12-check validation |
 
 ### Installing Skills
 


### PR DESCRIPTION
## Summary

Adds two Claude Code skills from [199 Biotechnologies](https://github.com/199-biotechnologies) to the Community Skills section:

- **[github-optimization-skill](https://github.com/199-biotechnologies/github-optimization-skill)** — Turn any GitHub repo into a star-magnet landing page. README optimization, SEO, and repo marketing.
- **[humanise-text-skill](https://github.com/199-biotechnologies/humanise-text-skill)** — Strip AI writing patterns from any text. 507-entry banned word list, structural pattern detection, and 12-check validation.

Both are open-source Claude Code skills with install instructions matching the existing table format.

## Checklist

- [x] Entries added to the Community Skills table in `README.md`
- [x] Format matches existing entries (Name link, install command, description)
- [x] Both repos are public and actively maintained

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added two new community skills to the reference guide: `github-optimization-skill` and `humanise-text-skill`, including installation instructions and descriptions of their capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->