### PR TITLE
Add Claudebase to All Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Over 176 production-ready plugins that extend Claude Code with domain-specific c
 | [ccusage](https://github.com/ryoppippi/ccusage) | CLI for analyzing Claude Code/Codex usage from local JSONL files. Daily, monthly, session, billing-window reports. Offline, zero API calls. 11,500+ stars |
 | [bundle-analyzer](plugins/bundle-analyzer/) | Frontend bundle size analysis and tree-shaking optimization |
 | [chief](https://github.com/MiniCodeMonkey/chief) | CLI that wraps Claude Code in a loop. Define a PRD, run chief, go do anything else. Commits after each task, picks up where it left off. Homebrew installable. 380+ stars |
+| [claudebase](https://github.com/rohithzr/claudebase) | Back up, restore, and sync your Claude Code config (settings, skills, agents, hooks, rules, memory, MCP) to a private GitHub repo. Named profiles, secret scanning, multi-machine conflict detection, automatic backups. 158 tests |
 | [changelog-gen](plugins/changelog-gen/) | Generate changelogs from git history with conventional commit parsing |
 | [changelog-writer](plugins/changelog-writer/) | Detailed changelog authoring from git history and PRs |
 | [ci-debugger](plugins/ci-debugger/) | Debug CI/CD pipeline failures and fix configurations |


### PR DESCRIPTION
Adds [Claudebase](https://github.com/rohithzr/claudebase) - a Claude Code plugin that backs up, restores, and syncs your entire Claude Code environment to a private GitHub repo.

Features:
- 6 skills: setup, push, pull, status, profiles, config
- Named profiles for switching between work/personal/team setups
- Secret scanning (API keys, PEM files, tokens)
- Multi-machine conflict detection
- Automatic backups before every pull
- 158 BATS tests, CI on macOS/Linux/Windows
- MIT licensed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new entry for the claudebase plugin to the plugins list. The plugin provides backup, restoration, and synchronization of Claude Code configuration through private repository storage. Includes support for named profiles, secret scanning, conflict detection, automatic backups, and secure configuration management across devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->