### PR TITLE
Add Marketing AI Toolkit directory to Ecosystem section

### DIFF
--- a/README.md
+++ b/README.md
@@ -966,6 +966,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [serena](https://github.com/oraios/serena) | 22,200+ | Semantic retrieval and editing MCP server for coding agents -- code-aware search and navigation |
 | [Understand-Anything](https://github.com/Lum1104/Understand-Anything) | 7,000+ | Turns any codebase into an interactive knowledge graph for exploration |
 | [n8n-mcp](https://github.com/czlonkowski/n8n-mcp) | 17,000+ | MCP for Claude Code to build and manage n8n automation workflows |
+| [Marketing AI Toolkit](https://ccromp.github.io/marketing-ai-toolkit/) | new | Curated directory of 230+ Claude Code skills and MCP servers quality-scored for marketing professionals -- SEO, content creation, email, social media, analytics, and ad copy. MarketCore Score system rates each tool on 5 dimensions |
 
 ---
 


### PR DESCRIPTION
## Add: Marketing AI Toolkit

Adding a curated, marketing-focused AI tool directory to the Ecosystem section.

### What it is
- **230+ tools** cataloged across SEO, content creation, email marketing, social media, analytics, and ad copy
- **MarketCore Score** system: 5-dimension quality rating (Installation, Documentation, Marketing Relevance, Output Quality, Maintenance)
- The only marketing-focused, quality-scored directory in the Claude Code ecosystem

**URL:** https://ccromp.github.io/marketing-ai-toolkit/  
**Repo:** https://github.com/ccromp/marketing-ai-toolkit

### Why it belongs in the Ecosystem section
The Ecosystem section covers "Notable projects, directories, and resources across the Claude Code ecosystem." This directory fills a genuine gap — a curated, quality-scored catalog of Claude Code skills and MCP servers evaluated specifically for marketing use cases. No equivalent resource exists in the ecosystem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Marketing AI Toolkit entry to the Ecosystem table, featuring 230+ Claude Code skills and quality-scored MCP servers for marketing use cases including SEO, content creation, email, social media, analytics, and ad copy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->