### PR TITLE
Add codachi statusline tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Claude Code Toolkit
 
-**The most comprehensive toolkit for Claude Code -- 135 agents, 35 curated skills (+400,000 via [SkillKit](https://agenstskills.com)), 42 commands, 176+ plugins, 20 hooks, 15 rules, 7 templates, 13 MCP configs, 26 companion apps, 51 ecosystem entries, and more.**
+**The most comprehensive toolkit for Claude Code -- 135 agents, 35 curated skills (+400,000 via [SkillKit](https://agenstskills.com)), 42 commands, 176+ plugins, 20 hooks, 15 rules, 7 templates, 13 MCP configs, 26 companion apps, 52 ecosystem entries, and more.**
 
 [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)


### PR DESCRIPTION
Added codachi next to claude-hud in the table. It's a different take on the statusline — instead of a dashboard it shows an ASCII pet that reacts to your session. Gets fatter with context usage, shows burn rate and cache hit ratio.

Repo: https://github.com/vincent-k2026/codachi

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated toolkit count/badge to reflect 52 ecosystem entries.
  * Added a new ecosystem entry for "codachi" — a Tamagotchi-style statusline pet showing context usage, cache hit rate, and burn speed (marked as "New").
<!-- end of auto-generated comment: release notes by coderabbit.ai -->