### PR TITLE
Add ClaudeCode Launchpad CLI to Companion Apps & GUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -905,7 +905,7 @@ claude-code-toolkit/               850+ files
 | [CCHub](https://github.com/Moresl/cchub) | New | Tauri 2.0 desktop app for managing the full Claude Code ecosystem -- MCP servers, skills, hooks, config profiles. Auto-scans Claude Code, Claude Desktop, Cursor configs |
 | [AionUI](https://github.com/iOfficeAI/AionUi) | 20,500+ | Free local open-source 24/7 Cowork app for Gemini CLI, Claude Code, Codex, and OpenCode |
 | [chops](https://github.com/Shpigford/chops) | 1,000+ | macOS app to browse, edit, and manage skills across Claude Code, Cursor, Codex, Windsurf, and Amp |
-| [ClaudeCode Launchpad CLI](https://github.com/noambrand/kivun-terminal) | 9 | Windows & macOS 2-minute installer for Claude Code — auto-installs Node.js, Git & Claude Code; two-line live status bar (model, context %, usage limits with reset timers); desktop shortcut with folder picker; optional light-blue theme; Claude flags support |
+| [ClaudeCode Launchpad CLI](https://github.com/noambrand/kivun-terminal) | 9 | Windows & macOS 2-minute installer for Claude Code — auto-installs Node.js, Git & Claude Code; two-line live status bar (model, context %, usage limits with reset timers); desktop shortcut with folder picker; right-click "Open with ClaudeCode Launchpad CLI" on any Windows folder; optional light-blue theme; Claude flags support |
 
 ---
 


### PR DESCRIPTION
## What's being added

**[ClaudeCode Launchpad CLI](https://github.com/noambrand/kivun-terminal)** — a 2-minute Windows & macOS installer for Claude Code.

Added to the **Companion Apps & GUIs** section.

## Why it fits here

Most Claude Code tools assume the user already has Node.js and Claude Code installed. ClaudeCode Launchpad CLI handles the entire setup in one step (auto-installs Node.js, Git, and Claude Code), then adds a persistent launcher with:

- **Two-line live status bar** — model name, context %, total tokens, session/weekly usage bars with time-until-reset
- **Desktop shortcut + folder picker** — double-click and choose a project folder; no `cd` needed
- **Right-click context menu** — "Open with ClaudeCode Launchpad CLI" on any folder (Windows)
- **Optional light-blue theme** — installer checkbox, or keep your existing terminal colors
- **Claude flags support** — persistent flags via `config.txt` or one-time flags per launch

It's the easiest way for Windows and macOS users to go from zero to a running Claude Code session.

## Repo
https://github.com/noambrand/kivun-terminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added ClaudeCode Launchpad CLI to the companion apps guide. Highlights: a ~2‑minute Windows/macOS installer with installer flow and desktop shortcut/folder picker, live two-line status bar (model, context %, usage), Windows folder right‑click integration, optional light‑blue theme, and support for Claude flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->