### PR TITLE
Add clideck to Companion Apps & GUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -905,6 +905,7 @@ claude-code-toolkit/               850+ files
 | [CCHub](https://github.com/Moresl/cchub) | New | Tauri 2.0 desktop app for managing the full Claude Code ecosystem -- MCP servers, skills, hooks, config profiles. Auto-scans Claude Code, Claude Desktop, Cursor configs |
 | [AionUI](https://github.com/iOfficeAI/AionUi) | 20,500+ | Free local open-source 24/7 Cowork app for Gemini CLI, Claude Code, Codex, and OpenCode |
 | [chops](https://github.com/Shpigford/chops) | 1,000+ | macOS app to browse, edit, and manage skills across Claude Code, Cursor, Codex, Windsurf, and Amp |
+| [clideck](https://github.com/rustykuntz/clideck) | 31 | WhatsApp-like dashboard for managing AI coding agents (Claude Code, Codex, Gemini CLI, OpenCode) in one browser window. Live status, session resume, autopilot routing between agents, mobile remote |
 
 ---
 


### PR DESCRIPTION
Adds [clideck](https://github.com/rustykuntz/clideck) to the Companion Apps & GUIs section.

clideck is a WhatsApp-like browser dashboard for managing Claude Code (and other AI coding agents) in one window. It does not sit in the middle — keys go straight to the agent. It watches lightweight OpenTelemetry status signals to show which agent is working, idle, or waiting.

- Live status detection for Claude Code
- Session resume — close the lid, reopen tomorrow
- Autopilot routes work between agents autonomously (~50 tokens per decision)
- Mobile remote to check in from a phone
- MIT license, runs locally

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added `clideck` to the list of companion apps and GUIs, a browser-based dashboard for managing AI coding agents with features including live status tracking, session resume, autopilot routing, and mobile remote access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->