### PR TITLE
Update claude-cost-optimizer: now an installable skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Over 176 production-ready plugins that extend Claude Code with domain-specific c
 | [claude-code-mcp](https://github.com/steipete/claude-code-mcp) | Run Claude Code as a one-shot MCP server -- an agent in your agent. Permissions bypassed automatically. By Peter Steinberger. 1,100+ stars |
 | [claude-code-system-prompts](https://github.com/Piebald-AI/claude-code-system-prompts) | Extracted system prompts from Claude Code -- 18 builtin tool descriptions, sub-agent prompts, utility prompts. Updated for each release. 5,900+ stars |
 | [claude-context](https://github.com/zilliztech/claude-context) | Semantic code search MCP server by Zilliz (Milvus creators). Hybrid BM25 + dense vector search. ~40% token reduction. 5,600+ stars |
-| [claude-cost-optimizer](https://github.com/Sagargupta16/claude-cost-optimizer) | Installable cost-mode skill (40-70% token savings) + 10 guides, Repo Analyzer, Cost Calculator, 10 templates, budget hooks. Install: `npx skills add Sagargupta16/claude-cost-optimizer` |
+| [claude-cost-optimizer](https://github.com/Sagargupta16/claude-cost-optimizer) | Installable cost-mode skill (30-60% cost savings, up to 70% in strict mode) + 10 guides, 10 templates, budget hooks. Install: `npx skills add Sagargupta16/claude-cost-optimizer` |
 | [fractal](https://github.com/rmolines/fractal) | Recursive project management for Claude Code. Decomposes goals into predicates, works the riskiest piece first, and re-evaluates as it learns |
 | [a11y-audit](plugins/a11y-audit/) | Full accessibility audit with WCAG compliance checking |
 | [accessibility-checker](plugins/accessibility-checker/) | Scan for accessibility issues and fix ARIA attributes in web applications |


### PR DESCRIPTION
Updates the existing claude-cost-optimizer entry to reflect that it's now an installable Claude Code skill (not just documentation).

**What changed**: The project now ships a `cost-mode` skill that reduces token usage 40-70%. Users install with `npx skills add Sagargupta16/claude-cost-optimizer` or via the official plugin marketplace.

**Updated description** includes: installable skill, Repo Analyzer (web tool), Cost Calculator, budget hooks, and the install command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Redescribed the claude-cost-optimizer as an installable "cost-mode skill" with an install command.
  * Updated savings guidance (30–60% typical, up to 70% in strict mode).
  * Streamlined listed guides/templates and added "budget hooks" to the feature set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->