### PR TITLE
Add sitemd plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ Over 176 production-ready plugins that extend Claude Code with domain-specific c
 | [screen-reader-tester](plugins/screen-reader-tester/) | Screen reader compatibility testing and ARIA fixes |
 | [security-guidance](plugins/security-guidance/) | Security best practices advisor with vulnerability detection and fixes |
 | [seed-generator](plugins/seed-generator/) | Database seeding script generation with realistic data |
+| [sitemd](https://github.com/sitemd-cc/sitemd) | Build websites from Markdown via MCP. 22 tools for creating pages, generating content, configuring settings, running SEO audits, and deploying static sites to Cloudflare Pages |
 | [slack-notifier](plugins/slack-notifier/) | Slack integration for deployment and build notifications |
 | [smart-commit](plugins/smart-commit/) | Intelligent git commits with conventional format, semantic analysis, and changelog generation |
 | [sprint-prioritizer](plugins/sprint-prioritizer/) | Sprint planning with story prioritization and capacity estimation |


### PR DESCRIPTION
Adds [sitemd-cc/sitemd](https://github.com/sitemd-cc/sitemd) to the All Plugins table.

sitemd is a Claude Code plugin and MCP server that builds websites from Markdown. 22 MCP tools cover page creation (`sitemd_pages_create`, `sitemd_pages_create_batch`), content generation, content validation, SEO audits, settings management, and one-command deployment to Cloudflare Pages.

- Repo: https://github.com/sitemd-cc/sitemd
- Site: https://sitemd.cc
- Insertion point: alphabetical, between `seed-generator` and `slack-notifier`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added `sitemd` plugin entry, documenting a solution for building websites from Markdown with integrated tools for page and content creation, settings configuration, SEO auditing, and static site deployment to Cloudflare Pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->