### PR TITLE
Add Anima to Companion Apps & GUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -894,6 +894,7 @@ claude-code-toolkit/               850+ files
 | [Claw](https://github.com/jamesrochabrun/Claw) | 86 | Native macOS app wrapping Claude Code SDK in Swift. Plan Mode, MCP Integration, Custom System Prompts |
 | [The Claude Protocol](https://github.com/AvivK5498/The-Claude-Protocol) | 149 | Enforcement layer wrapping Claude Code with 13 hooks -- blocks unsafe operations, enforces worktree isolation |
 | [Notch So Good](https://github.com/deepshal99/notch-so-good) | new | macOS notch-based session monitor with pixel-art companion, 13 animations, smart notifications, multi-session support |
+| [Anima](https://github.com/btangonan/anima) | new | Native macOS companion for Claude Code. Per-project ASCII familiars, nim token economy, cross-session watcher daemon. Tauri v2 + Rust, 4MB binary |
 | [crit](https://github.com/tomasz-tomczyk/crit) | 105 | Local browser UI for inline code review of any file or agent output; integrates with Claude Code via plan-hook to review and approve plans before execution, outputs structured .crit.json for agent consumption. |
 | [Untether](https://github.com/littlebearapps/untether) | 12 | Telegram bridge for Claude Code (and 5 other AI agents). Send tasks by voice or text, stream progress, approve changes with inline buttons from your phone |
 | [OctoAlly](https://github.com/ai-genius-automations/octoally) | 18 | AI coding session orchestration dashboard -- multi-agent hive-mind via RuFlo, Whisper voice dictation, tmux session persistence, built-in git source control, Electron desktop app |


### PR DESCRIPTION
Adds [Anima](https://github.com/btangonan/anima) to the Companion Apps & GUIs section.

**Anima** is a native macOS companion for Claude Code. Per-project ASCII familiars, nim token economy, cross-session watcher daemon. Tauri v2 + Rust, 4MB binary. MIT licensed.

- Tauri v2 + Rust backend + vanilla JS frontend
- 8 species, 10 color hues, 80 unique combinations across 5 rarity tiers
- Daemon monitors all active Claude Code sessions
- Oracle commentary via `claude -p` subprocess with companion personality
- 43 tests passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Anima to the Companion Apps & GUIs directory—a native macOS Claude Code companion application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->