### PR TITLE
Add Finance MCP config with Chart Library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Claude Code Toolkit
 
-**The most comprehensive toolkit for Claude Code -- 135 agents, 35 curated skills (+400,000 via [SkillKit](https://agenstskills.com)), 42 commands, 176+ plugins, 20 hooks, 15 rules, 7 templates, 13 MCP configs, 26 companion apps, 51 ecosystem entries, and more.**
+**The most comprehensive toolkit for Claude Code -- 135 agents, 35 curated skills (+400,000 via [SkillKit](https://agenstskills.com)), 42 commands, 176+ plugins, 20 hooks, 15 rules, 7 templates, 14 MCP configs, 26 companion apps, 51 ecosystem entries, and more.**
 
 [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)

--- a/mcp-configs/finance.json
+++ b/mcp-configs/finance.json
@@ -3,7 +3,6 @@
     "chart-library": {
       "command": "python",
       "args": ["-m", "chartlibrary_mcp"],
-      "env": {},
       "description": "Historical chart pattern search engine. Search 24M+ pre-computed embeddings across 15K+ symbols and 10 years of data. 19 tools for pattern matching, forward returns, regime analysis, anomaly detection, and trading signals. Free tier: 200 calls/day, no signup. Install: pip install chartlibrary-mcp"
     },
     "fetch": {


### PR DESCRIPTION
## Summary

Adds a new **Finance** MCP config (`mcp-configs/finance.json`) for financial research and trading analysis workflows.

### Servers included

- **Chart Library** (`chartlibrary-mcp`): Historical chart pattern search engine with 19 MCP tools. Searches 24M+ pre-computed embeddings across 15K+ symbols and 10 years of data. Returns similar patterns with forward returns, regime analysis, anomaly detection, and trading signals. Free tier: 200 calls/day, no signup. Install: `pip install chartlibrary-mcp`
- **Fetch**: For financial news, SEC filings, and web-based market data
- **Memory**: Track trade ideas, watchlists, and analysis findings across sessions

### Changes

- New file: `mcp-configs/finance.json`
- Updated README.md: added Finance row to MCP Configs table, updated count (13 -> 14)

### Setup

```json
{
  "mcpServers": {
    "chart-library": {
      "command": "python",
      "args": ["-m", "chartlibrary_mcp"],
      "env": {}
    }
  }
}
```

Website: https://chartlibrary.io
Repo: https://github.com/grahammccain/chart-library-mcp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README to reflect MCP Configs count increase (13 → 14) and TOC entry.

* **New Features**
  * Added a Finance MCP configuration exposing chart-pattern intelligence plus supporting Fetch and Memory server integrations for news, filings, market data, and session-persistent trade/watchlist storage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->