### PR TITLE
Security: Automatic `npx` execution may run untrusted code during hooks

### DIFF
--- a/hooks/scripts/type-check.js
+++ b/hooks/scripts/type-check.js
@@ -20,7 +20,13 @@ if (!fs.existsSync(path.join(tsconfigDir, "tsconfig.json"))) {
 }
 
 try {
-  execFileSync("npx", ["tsc", "--noEmit", "--pretty"], {
+  const tscBin = path.join(
+    tsconfigDir,
+    "node_modules",
+    ".bin",
+    process.platform === "win32" ? "tsc.cmd" : "tsc"
+  );
+  execFileSync(tscBin, ["--noEmit", "--pretty"], {
     stdio: "pipe",
     timeout: 30000,
     cwd: tsconfigDir,
@@ -37,7 +43,7 @@ try {
     JSON.stringify({
       typeCheck: "fail",
       file: filePath,
-      errors: relevantErrors || output.slice(0, 500),
+      errors: relevantErrors || output.slice(0, 500) || (e.message || "Type check failed"),
     })
   );
 }


### PR DESCRIPTION
## Problem

Multiple hooks invoke `npx` in response to file edits (`tsc`, `eslint`, `vitest`, `jest`, `prettier`). `npx` can execute packages from local or fetched sources; if tools are absent locally or dependency resolution is manipulated, this can trigger unintended code execution during routine editing operations.

**Severity**: `high`
**File**: `hooks/scripts/type-check.js`

## Solution

Avoid `npx` in auto-hooks. Resolve and execute pinned local binaries directly (e.g., `node_modules/.bin/eslint`) and enforce lockfile-based installs. If `npx` must be used, add `--no-install` and hard-fail when binaries are missing.

## Changes

- `hooks/scripts/type-check.js` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Enhanced type checking reliability by improving error reporting mechanisms to provide clearer feedback when type validation issues occur during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->