### PR TITLE
Add cc-aws-keepalive plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Over 176 production-ready plugins that extend Claude Code with domain-specific c
 | [claude-rank](https://github.com/Houseofmvps/claude-rank) | SEO/GEO/AEO audit plugin — tells you why AI won't cite your site, then auto-fixes robots.txt, sitemap.xml, llms.txt, and JSON-LD. 170+ rules across 10 scanners, zero config |
 | [claude-sounds](https://github.com/culminationAI/claude-sounds) | Audio feedback for Claude Code hooks — 10 events, 21 sounds, random rotation. macOS (`afplay`). |
 | [claude-code-hooks](https://github.com/yurukusa/claude-code-hooks) | 15 production-tested hooks from 160+ hours of autonomous operation. Destructive command blocker, branch guard, syntax check, context monitor, permission auto-approver. Bash, zero deps |
+| [cc-aws-keepalive](https://github.com/GeiserX/cc-aws-keepalive) | Keep Claude Code sessions alive through AWS credential expiry -- proactive expiration warnings, credential refresh bypass for Bedrock SSO/SAML, optional statusline countdown timer. 4 hook scripts, zero dependencies |
 | [cc-safe-setup](https://github.com/yurukusa/cc-safe-setup) | One command (`npx cc-safe-setup`) to install 6 essential safety hooks in 10 seconds. Zero dependencies |
 | [claude-supermemory](https://github.com/supermemoryai/claude-supermemory) | Persistent memory across sessions and projects using Supermemory. User profile injection at session start, automatic conversation capture. 2,300+ stars |
 | [code-architect](plugins/code-architect/) | Generate architecture diagrams and technical design documents |


### PR DESCRIPTION
Adds [cc-aws-keepalive](https://github.com/GeiserX/cc-aws-keepalive) to the All Plugins table.

**cc-aws-keepalive** keeps Claude Code sessions alive through AWS credential expiry. When using Claude Code with AWS Bedrock via SSO/SAML, credentials expire in memory and all sessions become unresponsive. This plugin provides 4 Node.js hook scripts that proactively warn before expiry, bypass the SDK's in-memory credential cache, and show an optional statusline countdown timer -- so you never need to restart Claude Code after re-authenticating.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a reference entry for the cc-aws-keepalive plugin describing its features: proactive expiration warnings, Bedrock SSO/SAML credential refresh bypass, optional statusline countdown, hook script counts, and zero dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->