### PR TITLE
Add toprank — SEO + Google Ads plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ Over 176 production-ready plugins that extend Claude Code with domain-specific c
 
 | [notch-so-good](https://github.com/deepshal99/notch-so-good) | Pixel-art crab (Chawd) lives in your Mac's notch and watches Claude Code for you. Live session timers, color-coded notifications, 13 idle animations, mouse-reactive eyes, drowsiness system. Universal binary, one-line install: `npx notch-so-good`. MIT, 130+ users |
 | [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) | Code intelligence MCP server — 42-language tree-sitter AST parsing, FalkorDB knowledge graphs, 0.944 MRR search quality. npm: `@anthropic/codegraph` |
+| [toprank](https://github.com/nowork-studio/toprank) | SEO + Google Ads plugin for Claude Code. Pulls real Search Console data and Google Ads API data, audits traffic and wasted ad spend, rewrites meta tags, generates JSON-LD schema, and ships the fixes. 9 skills across SEO, Ads, and cross-model review |
 
 ### Installing a Plugin
 


### PR DESCRIPTION
Adds toprank to All Plugins.

**What:** A Claude Code plugin (MIT) that gives Claude direct access to Google Search Console and the Google Ads API. Audits traffic, finds wasted ad spend, rewrites meta tags, generates JSON-LD schema markup, and actually ships the fixes to source / CMS. 9 skills: ads-audit, ads, ads-copy, seo-analysis, content-writer, keyword-research, meta-tags-optimizer, schema-markup-generator, setup-cms, plus a gemini cross-model review skill.

- Source: https://github.com/nowork-studio/toprank
- License: MIT
- Install: `/plugin marketplace add nowork-studio/toprank`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new plugin entry: `toprank`. This plugin provides comprehensive SEO and Google Ads management capabilities, including Search Console and Google Ads API data integration, traffic and spending auditing, meta tag optimization, JSON-LD schema generation, and bug fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->