### PR TITLE
Add cc-discipline to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Claude Code Toolkit
 
-**The most comprehensive toolkit for Claude Code -- 135 agents, 35 curated skills (+400,000 via [SkillKit](https://agenstskills.com)), 42 commands, 176+ plugins, 20 hooks, 15 rules, 7 templates, 14 MCP configs, 26 companion apps, 52 ecosystem entries, and more.**
+**The most comprehensive toolkit for Claude Code -- 135 agents, 35 curated skills (+400,000 via [SkillKit](https://agenstskills.com)), 42 commands, 176+ plugins, 20 hooks, 15 rules, 7 templates, 14 MCP configs, 26 companion apps, 53 ecosystem entries, and more.**
 
 [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)

--- a/README.md
+++ b/README.md
@@ -959,6 +959,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [oh-my-claudecode](https://github.com/Yeachan-Heo/oh-my-claudecode) | 9,900+ | Teams-first multi-agent orchestration with 19 specialized agents and 28 skills |
 | [ccusage](https://github.com/ryoppippi/ccusage) | 11,500+ | CLI for analyzing Claude Code usage from local JSONL files. Offline mode, zero API calls needed |
 | [cc-statistics](https://github.com/androidZzT/cc-statistics) | 270+ | Three-in-one Claude Code stats: CLI + Web + native macOS SwiftUI panel. Token costs, code changes by language, efficiency scoring, weekly reports. Supports Codex and Cursor too |
+| [cc-discipline](https://github.com/TechHU-GS/cc-discipline) | new | Guardrails for Claude Code — shell hooks that physically block bad behavior (edit loops, skipped verification, destructive git), not just markdown rules. Streak-breaker hard-stops at 5 edits, pre-edit-guard enforces debugging process, 7 rules, 7 skills, 2 subagents. Interactive installer with append mode. `bash ~/.cc-discipline/init.sh` |
 | [ccpm](https://github.com/automazeio/ccpm) | 7,600+ | Project management with GitHub Issues + Git worktrees for parallel agent execution |
 | [claude-code-system-prompts](https://github.com/Piebald-AI/claude-code-system-prompts) | 5,900+ | Extracted system prompts from Claude Code, updated for each release |
 | [claude-context](https://github.com/zilliztech/claude-context) | 5,600+ | Semantic code search MCP by Zilliz -- hybrid BM25 + vector search, ~40% token reduction |


### PR DESCRIPTION
## What

Adding [cc-discipline](https://github.com/TechHU-GS/cc-discipline) to the Ecosystem section.

## Why

cc-discipline takes a different approach from most Claude Code configuration tools: **shell hooks that physically block bad behavior** (`exit 2`), not just markdown rules that Claude can ignore.

Core hooks:
- **streak-breaker** — Tracks per-file edit counts. Warns at 3, hard-blocks at 5. Prevents the classic "edit the same file 8 times chasing symptoms" loop.
- **pre-edit-guard** — Blocks source code edits if `debug-log.md` has unverified hypotheses. Enforces a real debugging process.
- **post-error-remind** — Detects error patterns in Bash output and injects a diagnostic pause before Claude reacts impulsively.
- **git-guard** — Blocks destructive git commands (`reset --hard`, `push --force`, `clean -f`).

Also includes 7 auto-injected rules, 7 skills (`/think`, `/commit`, `/investigate`, `/self-check`, `/retro`, `/summary`, `/evaluate`), 2 subagents (reviewer + investigator), and tech-stack templates (Python, JS/TS, embedded, RTL, mobile).

Interactive installer with append mode — won't overwrite existing `.claude/` setup.

MIT licensed, npm installable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the README to reflect the ecosystem count increase (now 53 entries).
  * Added a new Ecosystem project entry for "cc-discipline" with repository link, status indicator, extended description, and installation instructions to help users discover and integrate the tool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->