### PR TITLE
Add vibe-replay to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1016,6 +1016,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [ToolRouter](https://toolrouter.com) | -- | Give Claude Code superpowers -- 150+ tools on demand with one account. Competitor research, video production, web search, image generation, security scanning, and more. `claude mcp add toolrouter -- npx -y toolrouter-mcp` |
 | [Claudoscope](https://github.com/cordwainersmith/claudoscope) | 29 | Native macOS menu bar app for Claude Code session analytics. Token/cost tracking, full-text search, real-time secret detection, config health linting (44 rules). Reads local JSONL files, fully offline, zero telemetry. Swift/SwiftUI, Homebrew install |
 | [LynxPrompt](https://github.com/GeiserX/LynxPrompt) | 25+ | Open-source platform for managing AI coding agent configs (CLAUDE.md, AGENTS.md, .cursorrules, copilot-instructions.md). Web marketplace, CLI, VS Code extension, self-hostable via Docker/Helm with federation support |
+| [vibe-replay](https://github.com/tuo-lei/vibe-replay) | new | Turn AI coding sessions into shareable, interactive HTML replays with animated playback, insights, and PR integration. Supports Claude Code and Cursor. [Website](https://vibe-replay.com) |
 
 ---
 


### PR DESCRIPTION
## Summary

Adds [vibe-replay](https://github.com/tuo-lei/vibe-replay) to the **Ecosystem** section.

**vibe-replay** is a CLI tool that turns AI coding sessions into shareable, interactive HTML replays. It parses Claude Code and Cursor session logs and generates self-contained HTML files with animated playback, session insights, and GitHub PR integration.

- **GitHub**: https://github.com/tuo-lei/vibe-replay
- **Website**: https://vibe-replay.com
- **npm**: https://www.npmjs.com/package/vibe-replay
- **Install**: `npx vibe-replay`

### Key features

- Animated, interactive playback of AI coding sessions
- Self-contained HTML output (zero external requests)
- Session insights and analytics
- GitHub PR integration (markdown summary + animated GIF)
- Supports Claude Code and Cursor
- Cloud sharing via GitHub Gist

![product-demo](https://github.com/user-attachments/assets/283383e8-3a78-4d9a-a17f-296d6e6c651f)
![session-preview-demo](https://github.com/user-attachments/assets/e8bba41a-534c-4cbe-b721-d4eb6caf5cc9)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added vibe-replay to the Ecosystem table—a new tool enabling shareable, interactive HTML replays of AI coding sessions with animated playback, insights, and PR integration. Supports Claude Code and Cursor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->