### PR TITLE
Fix cc-token-status URL (repo moved)

### DIFF
--- a/README.md
+++ b/README.md
@@ -944,7 +944,7 @@ claude-code-toolkit/               850+ files
 | [Onepilot](https://onepilotapp.com) | - | iOS app for running Claude Code, Codex, and other coding agents on remote servers via SSH from your phone. Full terminal emulator with SwiftTerm, agent session management, mobile access to dev machines |
 | [docker-claude-code](https://github.com/gw0/docker-claude-code) | new | Run Claude Code in an isolated Docker container with multi-profile support, security hardening, best-practice defaults, a set of pre-installed plugin/skill bundles and remote dev support. Drop-in replacement for `claude` — a simple shell alias is all it takes. |
 | [amux](https://github.com/mixpeek/amux) | new | Open-source agent multiplexer for running dozens of parallel Claude Code sessions with web dashboard, self-healing watchdog, kanban board, agent-to-agent REST API, and mobile PWA. Single Python file |
-| [cc-token-status](https://github.com/echowonderfulworld/cc-token-status) | new | macOS menu bar dashboard for Claude Code. Shows plan usage limits, costs, tokens, trends, model breakdown, and multi-machine sync via iCloud. Single Python file, auto-updates |
+| [cc-token-status](https://github.com/jayson-jia-dev/cc-token-status) | new | macOS menu bar dashboard for Claude Code. Shows live plan limits (5h/7d), costs, tokens, trends, model breakdown, user level system, and multi-machine iCloud sync. 5 languages, dark/light mode. Single Python file, auto-updates |
 
 ---
 


### PR DESCRIPTION
The cc-token-status repo moved from `echowonderfulworld` to `jayson-jia-dev`. GitHub redirects work but updating the URL for correctness.

Also updated the description to reflect new features (live plan limits, user level system, 5 languages, dark/light mode).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project reference documentation to include expanded feature descriptions (dashboard live plan limits, cost tracking, user level system, multi-device sync, multi-language support, and theme options).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->