### PR TITLE
Add Solo Orchestrator Framework - Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1016,6 +1016,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [ToolRouter](https://toolrouter.com) | -- | Give Claude Code superpowers -- 150+ tools on demand with one account. Competitor research, video production, web search, image generation, security scanning, and more. `claude mcp add toolrouter -- npx -y toolrouter-mcp` |
 | [Claudoscope](https://github.com/cordwainersmith/claudoscope) | 29 | Native macOS menu bar app for Claude Code session analytics. Token/cost tracking, full-text search, real-time secret detection, config health linting (44 rules). Reads local JSONL files, fully offline, zero telemetry. Swift/SwiftUI, Homebrew install |
 | [LynxPrompt](https://github.com/GeiserX/LynxPrompt) | 25+ | Open-source platform for managing AI coding agent configs (CLAUDE.md, AGENTS.md, .cursorrules, copilot-instructions.md). Web marketplace, CLI, VS Code extension, self-hostable via Docker/Helm with federation support |
+| [Solo Orchestrator](https://github.com/kraulerson/solo-orchestrator) | 4 | Phase-gated development methodology for building production-quality applications with Claude Code. One-command setup generates CLAUDE.md, CI/CD pipelines, pre-commit hooks, and security tooling. Auto-discovers new platforms and languages from the filesystem. Includes enterprise governance, intake wizard, and adversarial evaluation prompts. [Example project](https://github.com/kraulerson/solo-orchestrator-example-project) shows the complete artifact trail. |
 
 ---
 


### PR DESCRIPTION
**Solo Orchestrator Framework** (ecosystem) — A phase-gated
   software development methodology for building production-quality
   applications with Claude Code. Includes one-command setup (init.sh
   generates CLAUDE.md, CI/CD pipelines, pre-commit hooks, security
   tooling), auto-discovery extensibility for platforms and languages,
   enterprise governance with CIO business case, interactive intake
   wizard, and adversarial evaluation prompts. Two complete MVPs
   built with it (cross-platform desktop apps, all downloadable).
   MIT license.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * The Ecosystem section of the README has been expanded to include Solo Orchestrator, a new third-party project reference. The addition provides information about the project's GitHub repository, star count, and description, helping users discover additional ecosystem tools and resources available in the broader community.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->