### PR TITLE
Add product-org-os plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ Over 176 production-ready plugins that extend Claude Code with domain-specific c
 | [pr-reviewer](plugins/pr-reviewer/) | Review pull requests with structured analysis and approve with confidence |
 | [product-shipper](plugins/product-shipper/) | Ship features end-to-end with launch checklists and rollout plans |
 | [production-grade](https://github.com/nagisanzenin/claude-code-production-grade-plugin) | 14-agent autonomous pipeline — PM, Architect, Backend, Frontend, QA, Security, Code Review, DevOps, SRE, Data Scientist, Technical Writer, Skill Maker, Polymath co-pilot. Two-wave parallel execution, brownfield-safe. |
+| [product-org-os](https://github.com/yohayetsion/product-org-os) | 150+ skills and 12 role-based agents (CPO, VP Product, PM, PMM, BizOps, CI, and more) modeling a full product org. Two gateways: `/product` auto-routes to the right agent, `/plt` runs a multi-stakeholder leadership meeting. MIT. `claude plugins install github:yohayetsion/product-org-os` |
 | [project-scaffold](plugins/project-scaffold/) | Scaffold new projects and add features with best-practice templates |
 | [prompt-optimizer](plugins/prompt-optimizer/) | Analyze and optimize AI prompts for better results |
 | [pulse](https://github.com/chsm04/pulse) | Local Channel plugin — push notifications into Claude Code sessions via HTTP POST. No Discord/Slack needed, just curl. Three levels (info/warn/error), source tracking, dedup. |


### PR DESCRIPTION
Adds `product-org-os` to the Plugins table. It is a Claude Code plugin that models a full product organization as 12 role-based agents (CPO, VP Product, Director PM, Director PMM, PM, PMM, BizOps, BizDev, Competitive Intelligence, Product Ops, Value Realization, Product Mentor) with 150+ skills covering PRDs, roadmaps, business cases, GTM, pricing, and 31 strategy frameworks. v4.0 adds enforcement-first agent declarations, 38 knowledge packs, and 20 cross-domain specialist skills. Two gateways auto-route work: `/product` picks the right agent for a single task, `/plt` runs a multi-stakeholder Product Leadership Team meeting. Built on the Vision to Value 6-phase methodology, MIT licensed, installable with `claude plugins install github:yohayetsion/product-org-os`. Sits naturally alongside `the-pragmatic-pm` but covers the whole org rather than a single role.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new "product-org-os" plugin entry to the plugin directory with GitHub repository link, setup configuration details, and available routes for installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->