### PR TITLE
Add GateGuard to Hooks section

### DIFF
--- a/README.md
+++ b/README.md
@@ -766,7 +766,7 @@ Includes `--audit` (score your setup 0-100), `--scan` (detect tech stack, recomm
 
 ### GateGuard — Fact-Forcing PreToolUse Gate
 
-Install a single `PreToolUse` gate that blocks Edit/Write/Bash on first attempt, demanding investigation (importers, schemas, user instruction) before allowing. A/B tested: **+2.25 quality improvement**.
+Install a `PreToolUse` gate that blocks Edit/Write/Bash on first attempt, demanding investigation (importers, schemas, user instruction) before allowing. A/B tested: **+2.25 quality improvement**. Works as a standalone gate or alongside existing PreToolUse hooks — Claude Code runs all matching hooks in registration order, so GateGuard complements rather than replaces other guards.
 
 ```bash
 pip install gateguard-ai

--- a/README.md
+++ b/README.md
@@ -764,6 +764,17 @@ npx cc-safe-setup
 
 Includes `--audit` (score your setup 0-100), `--scan` (detect tech stack, recommend hooks), and `--verify` (test each hook). See [cc-safe-setup](https://github.com/yurukusa/cc-safe-setup) for details.
 
+### GateGuard — Fact-Forcing PreToolUse Gate
+
+Install a single `PreToolUse` gate that blocks Edit/Write/Bash on first attempt, demanding investigation (importers, schemas, user instruction) before allowing. A/B tested: **+2.25 quality improvement**.
+
+```bash
+pip install gateguard-ai
+gateguard install
+```
+
+See [GateGuard](https://github.com/zunoworks/gateguard) | [PyPI](https://pypi.org/project/gateguard-ai/) for details. By [ZUNO WORKS K.K.](https://github.com/zunoworks)
+
 ---
 
 ## Rules


### PR DESCRIPTION
## Summary

- Adds [GateGuard](https://github.com/zunoworks/gateguard) to the Hooks section — a pip-installable `PreToolUse` gate that blocks Edit/Write/Bash on first attempt, demanding investigation (importers, schemas, user instruction) before allowing
- A/B tested with **+2.25 quality improvement**
- Published on [PyPI](https://pypi.org/project/gateguard-ai/) by ZUNO WORKS K.K.

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Confirm links to repo and PyPI are valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a README subsection for GateGuard: installation steps, how to install and run the tool, description of the PreToolUse gate (it blocks Edit/Write/Bash on the first attempt until required investigation inputs are provided), notes on compatibility with existing PreToolUse hooks (registration-order execution), plus resource links and author attribution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->