### PR TITLE
Add whatsapp-claude-plugin: WhatsApp channel for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ Over 176 production-ready plugins that extend Claude Code with domain-specific c
 | [visual-regression](plugins/visual-regression/) | Visual regression testing with screenshot comparison |
 | [wshobson/agents](https://github.com/wshobson/agents) | 112 specialized agents, 16 multi-agent workflow orchestrators, 146 skills, 79 tools in 72 focused plugins. 31,300+ stars |
 | [web-dev](plugins/web-dev/) | Full-stack web development with app scaffolding and page generation |
+| [whatsapp-claude-plugin](https://github.com/Rich627/whatsapp-claude-plugin) | WhatsApp channel plugin for Claude Code -- connects as a linked device via Baileys v7 with bidirectional messaging, full media support, voice transcription, permission relay, and access control |
 | [workflow-optimizer](plugins/workflow-optimizer/) | Development workflow analysis and optimization recommendations |
 | [background-timer](https://github.com/culminationAI/background-timer) | Background timer with task notifications -- set delayed checks without blocking conversation |
 | [claude-sounds](https://github.com/culminationAI/claude-sounds) | Audio feedback for Claude Code hooks -- 10 events, 21 sounds, random rotation, customizable (macOS) |


### PR DESCRIPTION
## Summary

- Adds [whatsapp-claude-plugin](https://github.com/Rich627/whatsapp-claude-plugin) to the All Plugins table in README.md
- WhatsApp channel plugin for Claude Code, officially published on the Anthropic Plugin Marketplace
- Connects as a linked device via Baileys v7 with bidirectional messaging, full media support, voice transcription, permission relay, and access control

## Details

- **Plugin name:** whatsapp-claude-plugin
- **Author:** Richie Liu (Rich627)
- **Repo:** https://github.com/Rich627/whatsapp-claude-plugin
- Entry placed alphabetically between `web-dev` and `workflow-optimizer` in the All Plugins table

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added WhatsApp plugin entry documenting a new plugin for WhatsApp channel connectivity, supporting bidirectional messaging, full media support, voice transcription, permission relay, and access control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->