### PR TITLE
add: claude-token-lens — token attribution CLI for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Over 176 production-ready plugins that extend Claude Code with domain-specific c
 | [cc-safe-setup](https://github.com/yurukusa/cc-safe-setup) | One command (`npx cc-safe-setup`) to install 6 essential safety hooks in 10 seconds. Zero dependencies |
 | [knowledge-graph](https://github.com/hilyfux/knowledge-graph) | Built on Anthropic internal engineering practices and Karpathy's AutoResearch methodology. A zero-dependency, git-native memory layer for Claude Code that persists learned context across sessions. Pure bash, ~3ms/event, privacy-first |
 | [claude-supermemory](https://github.com/supermemoryai/claude-supermemory) | Persistent memory across sessions and projects using Supermemory. User profile injection at session start, automatic conversation capture. 2,300+ stars |
+| [claude-token-lens](https://github.com/wassimbensalem/claude-token-lens) | Real-time terminal dashboard that attributes token burn to specific tools, agents, MCP servers, and skills. Shows which agent or tool is eating your quota. Live TUI + CLI report + sessions breakdown. npm install -g claude-token-lens |
 | [code-architect](plugins/code-architect/) | Generate architecture diagrams and technical design documents |
 | [code-explainer](plugins/code-explainer/) | Explain complex code and annotate files with inline documentation |
 | [code-guardian](plugins/code-guardian/) | Automated code review, security scanning, and quality enforcement |


### PR DESCRIPTION
## What is this?

[claude-token-lens](https://github.com/wassimbensalem/claude-token-lens) is a real-time terminal dashboard that shows **which tool, agent, MCP server, or skill is burning your Claude Code quota** — turn by turn.

### Why it's different from ccusage

ccusage shows total usage stats (daily/monthly/session totals). claude-token-lens shows **attribution** — it traces every assistant turn back to its source:

- `tool: Bash` — how many tokens did shell commands cost?
- `agent: lead-engineer` — how much did that subagent run cost?
- `mcp: context7/resolve` — MCP lookup overhead?
- `[direct]` — pure Claude reasoning with no tools?

### Features

- **Live TUI dashboard** — real-time updating table, sorted by token burn
- **`report` command** — attribution breakdown + input overhead analysis (cache creation, cache read, heavy turns)
- **`sessions` command** — per-project/session breakdown with 5h window share
- **`status` command** — quick cross-project token snapshot
- Zero telemetry. Reads local JSONL files only.

### Install

```bash
npm install -g claude-token-lens
claude-token-lens --help
```

Published to npm: https://www.npmjs.com/package/claude-token-lens

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added `claude-token-lens` plugin entry to the "All Plugins" table in README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->