### PR TITLE
Add Helium MCP to Finance config

### DIFF
--- a/README.md
+++ b/README.md
@@ -834,7 +834,7 @@ Thirteen curated Model Context Protocol server configurations.
 | Design | [`design.json`](mcp-configs/design.json) | Figma design context, Blender 3D automation |
 | Workflow Automation | [`workflow-automation.json`](mcp-configs/workflow-automation.json) | n8n workflow builder, Pipedream integration |
 | Mobile | [`mobile.json`](mcp-configs/mobile.json) | Android ADB automation, Xcode build tools |
-| Finance | [`finance.json`](mcp-configs/finance.json) | Chart Library pattern intelligence, Fetch, Memory |
+| Finance | [`finance.json`](mcp-configs/finance.json) | Helium news/markets/options, Chart Library pattern intelligence, Fetch, Memory |
 
 ---
 

--- a/mcp-configs/finance.json
+++ b/mcp-configs/finance.json
@@ -1,5 +1,9 @@
 {
   "mcpServers": {
+    "helium": {
+      "url": "https://heliumtrades.com/mcp",
+      "description": "Real-time news with bias scoring across 5,000+ sources, live stock/ETF/crypto data with AI bull/bear cases and price forecasts, ML options pricing with probability ITM, balanced news synthesis, and meme search. 9 tools, free tier (50 queries), no API key needed."
+    },
     "chart-library": {
       "command": "python",
       "args": ["-m", "chartlibrary_mcp"],


### PR DESCRIPTION
## Summary

Adds [Helium MCP](https://github.com/connerlambden/helium-mcp) to the Finance MCP config alongside the existing Chart Library server.

Helium is a remote MCP server providing:
- **News intelligence**: Search 3.2M+ articles from 5,000+ sources with bias scoring across 15+ dimensions
- **Market data**: Live stock, ETF, and crypto prices with AI-generated bull/bear cases and price forecasts
- **Options analytics**: ML-powered fair value pricing, probability ITM, and ranked trading strategies
- **Balanced news**: Multi-perspective synthesis of any news topic
- **Meme search**: Semantic search across trending memes

9 tools, free tier (50 queries), no API key required. Remote streamable-HTTP server.

This naturally complements Chart Library's pattern intelligence with fundamental/news analysis and real-time pricing data.

## Changes
- `mcp-configs/finance.json`: Added Helium MCP server entry
- `README.md`: Updated Finance config description

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Helium integration: real-time news with bias scoring, live market data (stocks/ETFs/crypto) with AI bull/bear forecasts, options probability estimates and pricing, news synthesis, and meme search — free tier with no API key required.
* **Documentation**
  * Finance server list updated to include Helium among included services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->