### PR TITLE
Add aby-claude-watcher to Companion Apps & GUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -945,6 +945,7 @@ claude-code-toolkit/               850+ files
 | [docker-claude-code](https://github.com/gw0/docker-claude-code) | new | Run Claude Code in an isolated Docker container with multi-profile support, security hardening, best-practice defaults, a set of pre-installed plugin/skill bundles and remote dev support. Drop-in replacement for `claude` — a simple shell alias is all it takes. |
 | [amux](https://github.com/mixpeek/amux) | new | Open-source agent multiplexer for running dozens of parallel Claude Code sessions with web dashboard, self-healing watchdog, kanban board, agent-to-agent REST API, and mobile PWA. Single Python file |
 | [cc-token-status](https://github.com/echowonderfulworld/cc-token-status) | new | macOS menu bar dashboard for Claude Code. Shows plan usage limits, costs, tokens, trends, model breakdown, and multi-machine sync via iCloud. Single Python file, auto-updates |
+| [aby-claude-watcher](https://github.com/aby-agency/aby-claude-watcher) | new | Real-time macOS dashboard for Claude Code sessions. Five color-coded states (thinking, running, waiting, error, completed), per-session notifications, one-click focus terminal across iTerm2/Terminal/Warp/VSCode/Cursor/Ghostty/kitty/WezTerm/Hyper. Bilingual FR/EN, menu-bar tray, MIT licensed. Apple Silicon + Intel builds |
 
 ---
 


### PR DESCRIPTION
### Project

**[aby-claude-watcher](https://github.com/aby-agency/aby-claude-watcher)** — real-time macOS desktop app that monitors every Claude Code session running on the machine and surfaces its state at a glance.

### Highlights

- Auto-detects every session in `~/.claude/sessions/` with 2 s polling
- Five color-coded states: thinking / running / waiting / error / completed
- Grid and compact views with drag-to-reorder, always-on-top
- Per-session notifications (in-app toast + sound, 30 s cooldown)
- **One-click focus terminal** across iTerm2, Terminal, Warp, VSCode, Cursor, Ghostty, kitty, WezTerm, Hyper — walks the process tree from the session PID to the host terminal, then targets it via AppleScript
- Tool pills, token counters, cost estimation, git branch per session
- Bilingual FR/EN, menu-bar tray (duck silhouette template image), optional auto-launch
- Local-first: no telemetry, no phone-home; only network call is the manual update check
- MIT licensed
- Apple Silicon (arm64) and Intel (x64) builds — v1.0.0 released

### Release

https://github.com/aby-agency/aby-claude-watcher/releases/tag/v1.0.0

### Demo

Animated demos in the [README](https://github.com/aby-agency/aby-claude-watcher#readme).

Thanks for maintaining the toolkit 🙏

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added aby-claude-watcher to the companion apps list: a real-time macOS Claude Code session dashboard featuring multi-state color indicators, per-session notifications, one-click terminal focus across multiple applications, bilingual (FR/EN) support, and menu-bar tray integration. MIT licensed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->