### PR TITLE
Add ESP32-AI-Agent-Skill plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ Over 176 production-ready plugins that extend Claude Code with domain-specific c
 
 | [notch-so-good](https://github.com/deepshal99/notch-so-good) | Pixel-art crab (Chawd) lives in your Mac's notch and watches Claude Code for you. Live session timers, color-coded notifications, 13 idle animations, mouse-reactive eyes, drowsiness system. Universal binary, one-line install: `npx notch-so-good`. MIT, 130+ users |
 | [codebase-graph](https://github.com/Phoenixrr2113/codebase-graph) | Code intelligence MCP server — 42-language tree-sitter AST parsing, FalkorDB knowledge graphs, 0.944 MRR search quality. npm: `@anthropic/codegraph` |
+| [ESP32-AI-Agent-Skill](https://github.com/ezrover/ESP32-AI-Agent-Skill) | Expert ESP32 embedded systems plugin — chip selection across 9 variants, GPIO validation with anti-bricking safety, Arduino/ESP-IDF code gen, LVGL v8–v9.5 refs, 60+ Waveshare board pinouts. Install: `claude /install-plugin https://github.com/ezrover/ESP32-AI-Agent-Skill` |
 
 ### Installing a Plugin
 


### PR DESCRIPTION
Adds [ESP32-AI-Agent-Skill](https://github.com/ezrover/ESP32-AI-Agent-Skill) to the All Plugins table.

## Description

A Claude Code plugin for ESP32 embedded systems development:
- Chip selection guidance across 9 ESP32 variants (ESP32, S2, S3, C3, C6, C2, C5, H2, P4)
- GPIO pin validation with anti-bricking safety checks (strapping pins, flash pins, ADC2/WiFi conflicts)
- Code generation for Arduino and ESP-IDF frameworks
- LVGL reference docs (v8.2-v9.5) with migration guides
- 60+ Waveshare board pinout tables
- 50 automated tests, MIT licensed

Install: `claude /install-plugin https://github.com/ezrover/ESP32-AI-Agent-Skill`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added ESP32-AI-Agent-Skill plugin to the available plugins list with support for ESP32 embedded systems development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->