### PR TITLE
Add SuperSEO Skills to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -584,6 +584,7 @@ Thirty-five curated skill modules included in this repo, with access to **400,00
 | [j4rk0r/claude-skills](https://github.com/j4rk0r/claude-skills) | `npx skills add j4rk0r/claude-skills --yes --global` | 3 expert-grade skills: skill-guard (9-layer security auditor), skill-advisor (smart routing with gap analysis), skill-learner (persistent error correction). All A+ 120/120 on skill-judge |
 | [SciAgent-Skills](https://github.com/jaechang-hits/SciAgent-Skills) | `git clone https://github.com/jaechang-hits/SciAgent-Skills` | 197 life science skills for Claude Code covering genomics, proteomics, drug discovery, and more. BixBench 92.0% accuracy. |
 | [manage-skills](https://github.com/umutbozdag/agent-skills-manager/tree/main/skills/manage-skills) | `cp -r skills/manage-skills ~/.claude/skills/manage-skills` | Discover, create, edit, toggle, copy, move, and delete agent skills across 11 tools (Cursor, Claude, Windsurf, Copilot, Codex, Cline, Aider, Continue, Roo Code, Augment) from the terminal |
+| [SuperSEO Skills](https://github.com/inhouseseo/superseo-skills) | `/plugin marketplace add inhouseseo/superseo-skills` | 11 SEO skills for page audits, content briefs, article writing, E-E-A-T audits, semantic gap analysis, featured snippets, topic clusters, and link building. Each skill fetches pages and reads top-ranking competitors itself, so no keyword exports are needed. |
 
 ### Installing Skills
 


### PR DESCRIPTION
Adds [SuperSEO Skills](https://github.com/inhouseseo/superseo-skills) to the Community Skills table.

It's an 11-skill bundle for SEO workflows (page audits, content briefs, article writing, E-E-A-T audits, semantic gap analysis, featured snippets, topic clusters, link building). Apache 2.0, plugin marketplace install — `/plugin marketplace add inhouseseo/superseo-skills`.

The angle that's different from the existing marketing/SEO skills in this list: each skill fetches the page and reads the top-ranking competitors itself, so users don't paste in keyword data exports or crawl reports — just give it a URL or a keyword.

- Working SKILL.md + YAML frontmatter on every skill, complete reference docs bundled per skill.
- Tested in Claude Code, Claude Desktop, Claude.ai web (Skills tab), and Cursor.
- No generated attribution footers in the files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added SuperSEO Skills to the Skills table, featuring 11 SEO capabilities including page audits, content writing, E-E-A-T evaluation, semantic gap analysis, featured snippet optimization, topic clustering, and link building strategies with marketplace installation instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->