### PR TITLE
Add claude-token-lens to companion apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,6 @@ Over 176 production-ready plugins that extend Claude Code with domain-specific c
 | [ccmanager](https://github.com/kbwo/ccmanager) | Coding agent session manager supporting Claude Code, Gemini CLI, Codex, Cursor, Copilot, Cline, OpenCode, Kimi CLI. Smart auto-approval via Haiku, devcontainer support. 940+ stars |
 | [ccpm](https://github.com/automazeio/ccpm) | Project management using GitHub Issues + Git worktrees for parallel agent execution. Issue-analyze, epic-start, epic-merge commands. 7,600+ stars |
 | [ccusage](https://github.com/ryoppippi/ccusage) | CLI for analyzing Claude Code/Codex usage from local JSONL files. Daily, monthly, session, billing-window reports. Offline, zero API calls. 11,500+ stars |
-| [claude-token-lens](https://github.com/wassimbensalem/claude-token-lens) | Real-time token attribution CLI — see exactly which tool, agent, MCP server, or skill is burning your quota. Live Ink dashboard, burn rate, ETA, 5h + 7-day window. Zero telemetry. `npm install -g claude-token-lens` |
 | [building-multiagent-systems](https://github.com/2389-research/building-multiagent-systems) | Architecture patterns for multi-agent systems: orchestrator-worker, pipeline, debate, and MapReduce topologies |
 | [bundle-analyzer](plugins/bundle-analyzer/) | Frontend bundle size analysis and tree-shaking optimization |
 | [chief](https://github.com/MiniCodeMonkey/chief) | CLI that wraps Claude Code in a loop. Define a PRD, run chief, go do anything else. Commits after each task, picks up where it left off. Homebrew installable. 380+ stars |
@@ -959,6 +958,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [wshobson/agents](https://github.com/wshobson/agents) | 31,300+ | 112 specialized agents, 16 orchestrators, 146 skills, 79 tools in 72 focused plugins |
 | [oh-my-claudecode](https://github.com/Yeachan-Heo/oh-my-claudecode) | 9,900+ | Teams-first multi-agent orchestration with 19 specialized agents and 28 skills |
 | [ccusage](https://github.com/ryoppippi/ccusage) | 11,500+ | CLI for analyzing Claude Code usage from local JSONL files. Offline mode, zero API calls needed |
+| [claude-token-lens](https://github.com/wassimbensalem/claude-token-lens) | 587+ installs | Real-time token attribution from local Claude Code JSONL sessions — see which tool, agent, MCP server, or skill is burning your quota. Live Ink dashboard, burn rate, ETA, 5h + 7-day tracking, zero telemetry. `npm install -g claude-token-lens` |
 | [cc-statistics](https://github.com/androidZzT/cc-statistics) | 270+ | Three-in-one Claude Code stats: CLI + Web + native macOS SwiftUI panel. Token costs, code changes by language, efficiency scoring, weekly reports. Supports Codex and Cursor too |
 | [ccpm](https://github.com/automazeio/ccpm) | 7,600+ | Project management with GitHub Issues + Git worktrees for parallel agent execution |
 | [claude-code-system-prompts](https://github.com/Piebald-AI/claude-code-system-prompts) | 5,900+ | Extracted system prompts from Claude Code, updated for each release |

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Over 176 production-ready plugins that extend Claude Code with domain-specific c
 | [ccmanager](https://github.com/kbwo/ccmanager) | Coding agent session manager supporting Claude Code, Gemini CLI, Codex, Cursor, Copilot, Cline, OpenCode, Kimi CLI. Smart auto-approval via Haiku, devcontainer support. 940+ stars |
 | [ccpm](https://github.com/automazeio/ccpm) | Project management using GitHub Issues + Git worktrees for parallel agent execution. Issue-analyze, epic-start, epic-merge commands. 7,600+ stars |
 | [ccusage](https://github.com/ryoppippi/ccusage) | CLI for analyzing Claude Code/Codex usage from local JSONL files. Daily, monthly, session, billing-window reports. Offline, zero API calls. 11,500+ stars |
+| [claude-token-lens](https://github.com/wassimbensalem/claude-token-lens) | Real-time token attribution CLI — see exactly which tool, agent, MCP server, or skill is burning your quota. Live Ink dashboard, burn rate, ETA, 5h + 7-day window. Zero telemetry. `npm install -g claude-token-lens` |
 | [building-multiagent-systems](https://github.com/2389-research/building-multiagent-systems) | Architecture patterns for multi-agent systems: orchestrator-worker, pipeline, debate, and MapReduce topologies |
 | [bundle-analyzer](plugins/bundle-analyzer/) | Frontend bundle size analysis and tree-shaking optimization |
 | [chief](https://github.com/MiniCodeMonkey/chief) | CLI that wraps Claude Code in a loop. Define a PRD, run chief, go do anything else. Commits after each task, picks up where it left off. Homebrew installable. 380+ stars |


### PR DESCRIPTION
What
                                                                                                                                                
  Adds https://github.com/wassimbensalem/claude-token-lens to the companion apps table, alongside ccusage.
                                                                                                                                                
  Why it's different
                                                                                                                                                
  ccusage shows total usage (daily/monthly/session totals). claude-token-lens shows per-source attribution — which specific tool, agent, MCP    
  server, or skill consumed your tokens, in real time.
                                                                                                                                                
  Description                                     
                                         
  Reads Claude Code's local JSONL session files and attributes every token to its source using a two-pass parser.                               
   
  Features:                                                                                                                                     
  - Live Ink dashboard with quota progress bar, burn rate, ETA
  - Per-source breakdown: tool: Bash, agent: lead-engineer, mcp: context7/resolve, skill: /review                                               
  - 5h rolling window (rate-limit proxy) + 7-day weekly tracking                                 
  - Per-session tab switching (←→)                                                                                                              
  - report — scriptable text/JSON output                                                                                                        
  - status — cross-project aggregate (matches /stats in Claude Code)                                                                            
  - Zero telemetry, fully local, MIT license                                                                                                    
                                                                                                                                                
  npm install -g claude-token-lens                                                                                                              
  claude-token-lens live                                                                                                                        
                                                                                                                                                
  587+ downloads in first day on npm.            

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added the "claude-token-lens" entry to the ecosystem/plugins table with GitHub link, capability summary (real-time/local token attribution, dashboard, burn-rate/ETA, tracking windows), and global install instruction (`npm install -g claude-token-lens`), improving discoverability and setup guidance for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->