### PR TITLE
Add skill: deployhq/deployhq-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -582,6 +582,7 @@ Thirty-five curated skill modules included in this repo, with access to **400,00
 | [CSV Data Summarizer](https://github.com/coffeefuelbump/csv-data-summarizer-claude-skill) | `git clone` | Generate insights and summaries from CSV data files |
 | [tapestry](https://github.com/michalparkola/tapestry-skills-for-claude-code) | `git clone` | Knowledge networks, iterative learning, article extraction, and YouTube transcript processing |
 | [j4rk0r/claude-skills](https://github.com/j4rk0r/claude-skills) | `npx skills add j4rk0r/claude-skills --yes --global` | 3 expert-grade skills: skill-guard (9-layer security auditor), skill-advisor (smart routing with gap analysis), skill-learner (persistent error correction). All A+ 120/120 on skill-judge |
+| [deployhq-cli](https://github.com/deployhq/deployhq-cli) | `brew install deployhq/tap/dhq && dhq setup claude` | Deploy, rollback, and manage servers via DeployHQ CLI with --json output and breadcrumbs |
 | [SciAgent-Skills](https://github.com/jaechang-hits/SciAgent-Skills) | `git clone https://github.com/jaechang-hits/SciAgent-Skills` | 197 life science skills for Claude Code covering genomics, proteomics, drug discovery, and more. BixBench 92.0% accuracy. |
 | [manage-skills](https://github.com/umutbozdag/agent-skills-manager/tree/main/skills/manage-skills) | `cp -r skills/manage-skills ~/.claude/skills/manage-skills` | Discover, create, edit, toggle, copy, move, and delete agent skills across 11 tools (Cursor, Claude, Windsurf, Copilot, Codex, Cline, Aider, Continue, Roo Code, Augment) from the terminal |
 


### PR DESCRIPTION
Adds deployhq-cli to the Community Skills table.

**Skill:** [deployhq-cli](https://github.com/deployhq/deployhq-cli)

**What it does:** Agent skill for the DeployHQ CLI (`dhq`) — deploy code, rollback, manage servers and projects via the DeployHQ REST API. Features `--json` output with breadcrumbs (suggested next commands), `dhq commands --json` for self-discovery, and a SKILL.md agent guide with decision trees.

**Install:** `brew install deployhq/tap/dhq && dhq setup claude`

**License:** MIT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added deployhq-cli tool reference to the skills listing with installation instructions, GitHub repository link, and feature overview including server deployment and rollback management, operational capabilities, JSON output support, and breadcrumb navigation functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->