### PR TITLE
Add great_cto to All Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Over 176 production-ready plugins that extend Claude Code with domain-specific c
 | Plugin | Description |
 |--------|-------------|
 | [skills-janitor](https://github.com/khendzel/skills-janitor) | Audit, deduplicate, check, fix, and track usage of your Claude Code skills. 9 slash commands, zero dependencies |
+| [great_cto](https://github.com/avelikiy/great_cto) | Full SDLC pipeline plugin with 7 agents (tech-lead, senior-dev, qa-engineer, security-officer, devops, l3-support, project-auditor), 12-angle code review, 10 project archetypes, 13 compliance frameworks (SOC2/HIPAA/PCI-DSS/GDPR/ISO 27001), two-gate approval flow. Opus 4.7 advisor escalation, file-based, MIT |
 | [aws-cost-saver](https://github.com/prajapatimehul/aws-cost-saver) | AWS cost optimization scanner with 173 automated checks, ML-powered rightsizing, and Zero Hallucination Pricing - Real result: 60% cost reduction |
 | [claude-agentic-coding-playbook](https://github.com/john-wilmes/claude-agentic-coding-playbook) | Evidence-based practices for LLM-assisted development -- hooks, skills, scripts, and a best-practices guide with 58 citations. Includes 19+ guard/lifecycle hooks, investigation workflow, fleet indexing, and claude-loop for autonomous task queues. |
 | [claude-code-mcp](https://github.com/steipete/claude-code-mcp) | Run Claude Code as a one-shot MCP server -- an agent in your agent. Permissions bypassed automatically. By Peter Steinberger. 1,100+ stars |


### PR DESCRIPTION
Adds [great_cto](https://github.com/avelikiy/great_cto) to the **All Plugins** section of the Plugins table.

great_cto is a Claude Code plugin (v1.0.60, MIT) that runs a full SDLC pipeline with 7 specialized agents, 12-angle code review, 10 project archetypes, and 13 compliance frameworks. Two-gate approval flow: you approve architecture + ship, everything else is automated.

Format matches existing entries in the All Plugins table.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new plugin entry to the README documentation, including its repository link and detailed description of its capabilities and features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->