### PR TITLE
Add idle-timing plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ Over 176 production-ready plugins that extend Claude Code with domain-specific c
 | [github-issue-manager](plugins/github-issue-manager/) | GitHub issue triage, creation, and management |
 | [harness-evolver](https://github.com/raphaelchristi/harness-evolver) | LangSmith-native autonomous agent optimization. Multi-agent proposers evolve prompts, routing, tools, and architecture in isolated git worktrees. Install: `npx harness-evolver@latest` |
 | [helm-charts](plugins/helm-charts/) | Helm chart generation and upgrade management |
+| [idle-timing](https://github.com/clankercode/claude-inject-idle-time) | Injects hidden timing context (local time with UTC offset, idle seconds since last reply, previous-turn duration) into every user prompt so the model knows how long the conversation has been paused. Ships a statusline fragment for a live elapsed-time readout and a visible `[after Xm Ys]` note when you return from >10s idle. 57 tests, dual Unlicense/CC0. |
 | [import-organizer](plugins/import-organizer/) | Organize, sort, and clean import statements |
 | [infrastructure-maintainer](plugins/infrastructure-maintainer/) | Infrastructure maintenance with security audits and update management |
 | [ios-developer](plugins/ios-developer/) | iOS and Swift development with SwiftUI views and models |


### PR DESCRIPTION
Adds [idle-timing](https://github.com/clankercode/claude-inject-idle-time) to the All Plugins table.

**idle-timing** injects a hidden timing block (local time with UTC offset, idle seconds since last reply, previous-turn duration) into every user prompt, so the model knows how long ago the conversation paused. This fixes the "said good night, typed good morning 10 seconds later, Claude summarized yesterday" class of bug.

User-visible extras: a statusline fragment that prints elapsed time since the last reply (`45s`, `3m 21s`, `1h 23m`), and a `[after Xm Ys]` re-entry note when you send a prompt after >10s idle.

- **Hooks:** UserPromptSubmit, Stop, PreCompact
- **Tests:** 57 passing
- **License:** dual Unlicense/CC0
- **Install:** `/plugin marketplace add clankercode/claude-inject-idle-time` then `/plugin install idle-timing@idle-info`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added `idle-timing` plugin documentation to the complete plugins list. This plugin enhances user experience by injecting timing context into prompts, providing elapsed-time display in the statusline, and showing a visible idle indicator when inactive for more than 10 seconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->