### PR TITLE
Add cc-hud to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1009,6 +1009,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [planning-with-files](https://github.com/OthmanAdi/planning-with-files) | 17,600+ | Manus-style persistent markdown planning skill for structured project management |
 | [claude-hud](https://github.com/jarrodwatts/claude-hud) | 15,200+ | Plugin showing context usage, active tools, running agents, todo progress in a HUD overlay |
 | [codachi](https://github.com/vincent-k2026/codachi) | New | Tamagotchi-style statusline pet that grows with context usage, shows cache hit rate and burn speed |
+| [cc-hud](https://github.com/WaterTian/cc-hud) | New | Compact single-line Claude Code statusline -- model, context usage (1/8-char progress bar), active subagents, 5h/7d rate-limit countdowns. Pure Node.js, zero deps, Windows-safe. |
 | [awesome-claude-code-subagents](https://github.com/VoltAgent/awesome-claude-code-subagents) | 15,600+ | 100+ specialized Claude Code subagents organized by domain |
 | [serena](https://github.com/oraios/serena) | 22,200+ | Semantic retrieval and editing MCP server for coding agents -- code-aware search and navigation |
 | [Understand-Anything](https://github.com/Lum1104/Understand-Anything) | 7,000+ | Turns any codebase into an interactive knowledge graph for exploration |


### PR DESCRIPTION
Adds cc-hud, a compact single-line Claude Code statusline.

- Shows model, context usage (1/8-char progress bar), active subagents, 5h/7d rate-limit countdowns
- Install: `/plugin marketplace add WaterTian/cc-hud`
- npm: cc-hud v0.2.4 (MIT)
- Pure Node.js >=18, zero dependencies, Catppuccin Mocha colors

Fits alongside existing statusline entries in Ecosystem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added `cc-hud` to the ecosystem: a lightweight single-line Claude Code statusline featuring model information, context usage progress bar, active subagent tracking, and rate-limit countdowns with zero dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->