### PR TITLE
Add claude-memory-kit skill

### DIFF
--- a/skills/claude-memory-kit/SKILL.md
+++ b/skills/claude-memory-kit/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: claude-memory-kit
+description: "Persistent memory system for Claude Code. Two-layer architecture (hot cache + knowledge wiki), safety hooks, /close-day end-of-day synthesis. Zero external dependencies."
+author: awrshift
+version: 3.2.0
+tags: [memory, context-management, productivity, agent-memory]
+repository: https://github.com/awrshift/claude-memory-kit
+license: MIT
+---
+
+# Claude Memory Kit
+
+Your Claude agent remembers everything across sessions and projects.
+
+## What it does
+
+- **Persistent memory** — MEMORY.md hot cache + knowledge wiki with [[wikilinks]]
+- **Multi-project support** — per-project backlogs and context isolation
+- **Safety hooks** — prevent context loss during compression and long sessions
+- **`/close-day`** — one command captures your entire day
+- **`/tour`** — interactive guided walkthrough
+
+## Quick Start
+
+```bash
+git clone https://github.com/awrshift/claude-memory-kit.git my-project
+cd my-project
+claude
+```
+
+## Built from production
+
+700+ sessions across 7 projects. Adapted from Karpathy/Cole Medin's knowledge base pattern, simplified for daily CLI use.


### PR DESCRIPTION
## What

Adds `claude-memory-kit` to the skills directory — a persistent memory system for Claude Code.

## Repo

https://github.com/awrshift/claude-memory-kit

## Key features

- Two-layer memory: hot cache (MEMORY.md) + knowledge wiki
- Safety hooks prevent context loss during compression
- `/close-day` end-of-day synthesis in one command
- Multi-project support with per-project backlogs
- Zero external dependencies, MIT license
- 700+ production sessions across 7 projects

## Files added

- `skills/claude-memory-kit/SKILL.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the claude-memory-kit skill, detailing its persistent memory system, multi-project backlogs, context isolation, safety features, and included commands for end-of-day synthesis and guided walkthroughs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->