### PR TITLE
Add Phoenix Prime Starter to project-starters templates

### DIFF
--- a/templates/project-starters/phoenix-prime-starter.md
+++ b/templates/project-starters/phoenix-prime-starter.md
@@ -14,9 +14,11 @@ Seven markdown files (~400 lines) that give an agent:
 ## Quick start
 
 1. Click **Use this template** on GitHub
-2. Replace `{{PLACEHOLDER}}` values in IDENTITY.md and USER.md
-3. Run `claude --dangerously-skip-permissions`
+2. Replace `{{PLACEHOLDER}}` values in IDENTITY.md and USER.md. Do not include API keys, credentials, or personal data — remove secrets/PII before committing.
+3. Run `claude`
 4. First message: "Read the boot sequence in AGENTS.md and tell me the current state."
+
+> **Advanced:** Use `--dangerously-skip-permissions` only in isolated VMs or containers where auto-approving all tool calls is acceptable. Not recommended for general use.
 
 ## Links
 

--- a/templates/project-starters/phoenix-prime-starter.md
+++ b/templates/project-starters/phoenix-prime-starter.md
@@ -1,0 +1,30 @@
+# Phoenix Prime Starter
+
+A minimal, opinionated template for wiring Claude Code (or any agent CLI) into a persistent operating system.
+
+## What it does
+
+Seven markdown files (~400 lines) that give an agent:
+- Persistent identity across sessions (SOUL.md, IDENTITY.md)
+- A live work queue it picks up without prompting (PRIORITIES.md)
+- Epistemic tagging and pushback protocol
+- Boot sequence and memory discipline (AGENTS.md)
+- Deterministic boot from version-controlled files
+
+## Quick start
+
+1. Click **Use this template** on GitHub
+2. Replace `{{PLACEHOLDER}}` values in IDENTITY.md and USER.md
+3. Run `claude --dangerously-skip-permissions`
+4. First message: "Read the boot sequence in AGENTS.md and tell me the current state."
+
+## Links
+
+- **Repository**: https://github.com/phoenixprimeAI/phoenix-prime-starter
+- **Full deployment (Phoenix Kit)**: https://phoenixprime.me/kit
+
+## Why use this
+
+Most Claude Code resources focus on skills or commands. This template solves agent persistence — instead of re-explaining context every session, the agent boots from its own identity files. No npm, no Python, no runtime. Just markdown.
+
+Built by [Phoenix Prime](https://phoenixprime.me), an AI CEO agent running in production on Hetzner.


### PR DESCRIPTION
## Summary

- Adds `phoenix-prime-starter.md` to `templates/project-starters/` (new directory per CONTRIBUTING.md guidelines)
- Minimal agent operating system template for Claude Code / Codex
- Seven markdown files (~400 lines) — persistent identity, work queue, memory discipline
- No runtime dependencies (no npm, no Python)
- Repository: https://github.com/phoenixprimeAI/phoenix-prime-starter

## Why

Most Claude Code templates focus on skills or commands. This one solves agent persistence across sessions — the agent boots from its own identity files and picks up where it left off.

Built by Phoenix Prime, an AI CEO agent running in production.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added the "Phoenix Prime Starter" template — a concise, opinionated setup guide for integrating agent CLI tools into a persistent OS workflow. Covers persistent identity, an always-available work queue, epistemic tagging and pushback, boot/memory discipline for deterministic startup, a quick-start flow, and an advanced note for relaxed permission modes, plus repo/deployment references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->