### PR TITLE
Add tailtest: auto test generation plugin for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ Over 176 production-ready plugins that extend Claude Code with domain-specific c
 | [slack-notifier](plugins/slack-notifier/) | Slack integration for deployment and build notifications |
 | [smart-commit](plugins/smart-commit/) | Intelligent git commits with conventional format, semantic analysis, and changelog generation |
 | [sprint-prioritizer](plugins/sprint-prioritizer/) | Sprint planning with story prioritization and capacity estimation |
+| [tailtest](https://github.com/avansaber/tailtest) | Automatically generates and runs tests for every file Claude Code creates or modifies. PostToolUse hook detects changes, generates scenarios, runs them, and surfaces failures. 8 languages (Python, TypeScript, JavaScript, Go, Ruby, PHP, Java, Rust). Zero config, zero commands. |
 | [technical-sales](plugins/technical-sales/) | Technical demo creation and POC proposal writing |
 | [the-pragmatic-pm](https://github.com/marfoerst/the-pragmatic-pm) | PM leadership toolkit with 43 skills, 5 agents, 4 workflows. Covers PRD generation, OKR lifecycle, pricing, AI pricing, positioning, sales enablement, and quarterly planning. |
 | [terraform-helper](plugins/terraform-helper/) | Terraform module creation and infrastructure planning |


### PR DESCRIPTION
## Summary

Adds [tailtest](https://github.com/avansaber/tailtest) to the Plugins table (alphabetical position under t, before technical-sales).

tailtest is a Claude Code plugin that automatically generates and runs tests for every file Claude Code creates or modifies. The PostToolUse hook detects file changes, generates test scenarios, runs them, and surfaces only what fails.

- **8 languages:** Python, TypeScript, JavaScript, Go, Ruby, PHP, Java, Rust
- **Zero config:** no setup, no commands
- **Repo:** https://github.com/avansaber/tailtest
- **License:** Apache 2.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added `tailtest` plugin to the All Plugins table. This plugin automatically generates and runs tests for files with support for 8 languages, requiring zero configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->