### PR TITLE
add: awesome-claude-design to related lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -1133,6 +1133,7 @@ Tutorials, guides, and deep-dives on Claude Code.
 | [awesome-claude-code-subagents](https://github.com/VoltAgent/awesome-claude-code-subagents) | 15,600+ | 100+ specialized Claude Code subagents |
 | [claude-code-best-practice](https://github.com/shanraisshan/claude-code-best-practice) | 25,000+ | Comprehensive reference implementation for Claude Code config |
 | [awesome-claude-skills (Composio)](https://github.com/ComposioHQ/awesome-claude-skills) | 49,300+ | 30 curated skills + 832 SaaS automation templates via Composio. Strong on document processing, creative, and business skills |
+| [awesome-claude-design](https://github.com/rohitg00/awesome-claude-design) | ![Stars](https://img.shields.io/github/stars/rohitg00/awesome-claude-design?style=flat-square&label=) | DESIGN.md files grouped by aesthetic family (editorial, terminal, warm, data-dense, cinematic, playful, glass, brutalist, indie) + remix recipes + prompt packs for Claude Design (Anthropic Labs) |
 
 ## Contributing
 


### PR DESCRIPTION
Cross-link to sibling repo covering **Claude Design** (Anthropic Labs, launched April 17, 2026).

**What it is:** DESIGN.md files grouped by aesthetic family (not industry) — editorial minimalism, terminal-core, warm editorial, data-dense pro, cinematic dark, playful color, glass / soft-futurism, neon brutalist, cult / indie. Plus remix recipes (Linear × Claude, Warp × Sentry, Stripe × A24), prompt packs with example outputs, skills, comparisons vs Lovable / v0 / Stitch / SuperDesign, video teardowns, X signal, honest community takes.

**Why list here:** complements the Claude Code toolkit ecosystem — Design is upstream of Code for most product work.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added `awesome-claude-design` to the Related Awesome Lists section in the README, featuring design resources and prompt packs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->