### PR TITLE
Add planmysaas to Community Skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -625,6 +625,7 @@ Thirty-five curated skill modules included in this repo, with access to **400,00
 | [Coware](https://github.com/shitianfang/coware-skills) | `npx skills add shitianfang/coware-skills` | Syncs shared API specs across AI coding agents — prevents merge conflicts from mismatched interfaces, field names, or return types. Auto-pulls latest specs, walks agents through setup for new projects |
 | [humanize-chinese](https://github.com/voidborne-d/humanize-chinese) | `clawhub install humanize-chinese` | Detects and rewrites AI-generated Chinese text. Two-layer detection (20+ rule dimensions + N-gram perplexity), 0-100 scoring, 7 style transforms, academic paper AIGC reduction. 4 slash commands: /detect, /humanize, /academic, /style |
 | [BeHuman](https://github.com/voidborne-d/behuman) | `clawhub install behuman` | Adds inner dialogue to AI responses via Self-Mirror consciousness loop — Self generates instinctive response, Mirror exposes filler/performative empathy, Self revises into real human reply. Based on Lacan's Mirror Stage, Kahneman's Dual Process Theory. MIT |
+| [planmysaas](https://github.com/creationskiro/planmysaas-claude-skill) | `git clone https://github.com/creationskiro/planmysaas-claude-skill ~/.claude/skills/planmysaas` | Turns idea to a complete 8-stage SaaS blueprint — idea, research, analysis, architecture, features, frontend, phases, build playbook. Stage 8 ships a decision-grade, rubric-graded build playbook with dependency-ordered steps. Plain markdown, MIT, v1.0.0. |
 
 ### Installing Skills
 


### PR DESCRIPTION
## Skill: planmysaas

**Repo:** https://github.com/creationskiro/planmysaas-claude-skill
**License:** MIT · **Release:** v1.0.0

### What it does
Turns a one-line idea into a complete 8-stage SaaS blueprint:

1. Idea refine
2. Research
3. Analysis (PMF, SWOT, TAM/SAM/SOM, Porter's 5F, BMC, GTM)
4. Architecture
5. Features
6. Frontend
7. Phases
8. Decision-grade build playbook (rubric-graded, dependency-ordered, leaf to root)

### Why this list
Plain markdown skill, no build step, MIT, 0 dependencies, v1.0.0 release. Slots into the Community Skills table.

### Install
```bash
git clone https://github.com/creationskiro/planmysaas-claude-skill ~/.claude/skills/planmysaas
```
Then `/planmysaas "<your idea>"` from inside Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new community skill entry for planmysaas, including GitHub link, installation instructions, and details about an 8-stage SaaS blueprint with rubric-graded build playbook.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->