### PR TITLE
Add Agent Shadow Brain and Omni Skills Forge to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1012,6 +1012,8 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | Name | Stars | Description |
 |------|-------|-------------|
 | [claude-mem](https://github.com/thedotmack/claude-mem) | 35,900+ | Auto-captures everything Claude does, compresses with AI, injects context into future sessions. #1 trending GitHub Feb 2026 |
+| [Agent Shadow Brain](https://github.com/theihtisham/agent-shadow-brain) | 6+ | Self-evolving AI coding intelligence with infinite memory (TurboQuant), genetic evolution, predictive bug detection, PageRank knowledge graphs, and swarm intelligence. [npm](https://www.npmjs.com/package/@theihtisham/agent-shadow-brain) |
+| [Omni Skills Forge](https://github.com/theihtisham/omni-skills-forge) | 10+ | 50,000+ curated AI agent skills for Claude Code, Cursor, Copilot, Windsurf, Cline. Visual dashboard, one-click install, skill doctor. [npm](https://www.npmjs.com/package/omni-skills-forge) |
 | [wshobson/agents](https://github.com/wshobson/agents) | 31,300+ | 112 specialized agents, 16 orchestrators, 146 skills, 79 tools in 72 focused plugins |
 | [oh-my-claudecode](https://github.com/Yeachan-Heo/oh-my-claudecode) | 9,900+ | Teams-first multi-agent orchestration with 19 specialized agents and 28 skills |
 | [ccusage](https://github.com/ryoppippi/ccusage) | 11,500+ | CLI for analyzing Claude Code usage from local JSONL files. Offline mode, zero API calls needed |


### PR DESCRIPTION
Add Agent Shadow Brain (self-evolving AI coding intelligence) and Omni Skills Forge (50K+ AI skills library) to the Ecosystem section.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added two new entries to the Ecosystem section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->