### PR TITLE
fix(hooks): add path traversal guard to file_path hook scripts

### DIFF
--- a/hooks/scripts/auto-test.js
+++ b/hooks/scripts/auto-test.js
@@ -5,6 +5,7 @@ const fs = require("fs");
 const input = JSON.parse(process.argv[2] || "{}");
 const filePath = input.file_path || input.filePath || "";
 if (!filePath) process.exit(0);
+if (!path.resolve(filePath).startsWith(process.cwd() + path.sep) && path.resolve(filePath) !== process.cwd()) process.exit(0);
 
 const ext = path.extname(filePath).toLowerCase();
 if (![".ts", ".tsx", ".js", ".jsx", ".py", ".go", ".rs"].includes(ext)) process.exit(0);

--- a/hooks/scripts/lint-fix.js
+++ b/hooks/scripts/lint-fix.js
@@ -4,6 +4,7 @@ const path = require("path");
 const input = JSON.parse(process.argv[2] || "{}");
 const filePath = input.file_path || input.filePath || "";
 if (!filePath) process.exit(0);
+if (!path.resolve(filePath).startsWith(process.cwd() + path.sep) && path.resolve(filePath) !== process.cwd()) process.exit(0);
 
 const ext = path.extname(filePath).toLowerCase();
 

--- a/hooks/scripts/post-edit-check.js
+++ b/hooks/scripts/post-edit-check.js
@@ -4,6 +4,7 @@ const path = require("path");
 const input = JSON.parse(process.argv[2] || "{}");
 const filePath = input.file_path || input.filePath || "";
 if (!filePath) process.exit(0);
+if (!path.resolve(filePath).startsWith(process.cwd() + path.sep) && path.resolve(filePath) !== process.cwd()) process.exit(0);
 
 const ext = path.extname(filePath).toLowerCase();
 const lintCommands = {


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Security Fix (Medium severity)

Three hook scripts pass `file_path` from hook input directly to subprocess commands without verifying the path is within the project directory:

- `hooks/scripts/auto-test.js`
- `hooks/scripts/post-edit-check.js`
- `hooks/scripts/lint-fix.js`

**Issue:** `file_path` arrives from the Claude Code hook event payload. While `execFileSync` with array args does not invoke a shell (so direct shell injection is not possible), a crafted filename pointing outside the repository could cause these scripts to run tests or linters on arbitrary paths on the filesystem — for example, `/etc/passwd` or a path in another project.

**Fix:** One line added to each file immediately after the empty-path check:

```js
if (!path.resolve(filePath).startsWith(process.cwd() + path.sep) && path.resolve(filePath) !== process.cwd()) process.exit(0);
```

This resolves the path to an absolute form (neutralising `../..` traversal), then confirms it is inside `process.cwd()` before proceeding. If the path escapes the project root, the hook exits silently — the same behaviour as when the extension is unsupported.

No behaviour change for legitimate in-project file paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Strengthened path validation in auto-test, lint-fix, and post-edit-check scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->