### PR TITLE
fix(hooks): verify tmux socket existence in block-dev-server.js

### DIFF
--- a/hooks/scripts/block-dev-server.js
+++ b/hooks/scripts/block-dev-server.js
@@ -1,3 +1,4 @@
+const fs = require("fs");
 const input = JSON.parse(process.argv[2] || "{}");
 const command = (input.command || "").toLowerCase();
 
@@ -24,7 +25,8 @@ if (!isDevServer) {
   process.exit(0);
 }
 
-const inTmux = !!process.env.TMUX;
+const tmuxSocket = process.env.TMUX ? process.env.TMUX.split(",")[0] : null;
+const inTmux = !!(tmuxSocket && fs.existsSync(tmuxSocket));
 const inScreen = !!process.env.STY;
 
 if (!inTmux && !inScreen) {


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Security Fix (Low severity)

The dev-server block in `hooks/scripts/block-dev-server.js` relies on `process.env.TMUX` and `process.env.STY` to determine whether Claude is running inside a terminal multiplexer before allowing dev server commands.

**Issue:** Environment variables can be set by any parent process. A process that inherited `TMUX` from a previous session, or that was launched with `TMUX` explicitly set in its environment, would bypass the guard — even though no actual tmux session is active.

**Fix:** The `TMUX` variable is always set to the tmux socket path followed by a PID and window index, e.g. `/tmp/tmux-1000/default,3120,0`. The socket file only exists while a real tmux server is running. This PR checks that the socket file exists:

```js
const tmuxSocket = process.env.TMUX ? process.env.TMUX.split(",")[0] : null;
const inTmux = !!(tmuxSocket && fs.existsSync(tmuxSocket));
```

If `TMUX` is set but the socket file is gone (stale env, spoofed env, or tmux server exited), `inTmux` is `false` and the guard behaves correctly.

Note: The `STY` (GNU screen) check is left unchanged — screen session names do not map to a simple filesystem path, so a similar check is not straightforward without a subprocess call.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dev-server blocker reliability by strengthening environment validation checks, ensuring more accurate detection in relevant contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->