### PR TITLE
Add new-skill: styleseed design judgment engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,6 +558,7 @@ Thirty-five curated skill modules included in this repo, with access to **400,00
 | WebSocket & Realtime | `skills/websocket-realtime/` | Socket.io, SSE, reconnection, scaling |
 | Testing Strategies | `skills/testing-strategies/` | Contract testing, snapshot testing, property-based testing |
 | Git Advanced | `skills/git-advanced/` | Worktrees, bisect, interactive rebase, hooks |
+| [StyleSeed](https://github.com/bitjaru/styleseed) | `skills/styleseed/` | Design judgment: 69 visual rules, brand skins, professional UI |
 | Accessibility (WCAG) | `skills/accessibility-wcag/` | ARIA patterns, keyboard navigation, color contrast |
 | Performance Optimization | `skills/performance-optimization/` | Code splitting, image optimization, Core Web Vitals |
 | Mobile Development | `skills/mobile-development/` | React Native, Flutter, responsive layouts |

--- a/skills/styleseed/SKILL.md
+++ b/skills/styleseed/SKILL.md
@@ -1,0 +1,35 @@
+# StyleSeed — Design Judgment Engine
+
+> Teaches Claude Code design judgment, not just design data. 69 visual rules that make AI output look designed, not generated.
+
+## What It Teaches
+
+- **Color discipline** — `#2A2A2A` as refined black, 5-level grayscale, one accent color maximum
+- **Spatial rhythm** — alternating section heights, 2:1 number-to-unit ratios
+- **Information hierarchy** — card/background separation, progressive density
+- **Shadow & elevation** — 4% opacity ceiling, dark mode border substitution
+- **Component variance** — never 4 identical KPI cards, stagger content types
+- **Motion & feedback** — 200ms normal, spring for entrance, ease-out for exit
+
+## Quick Start
+
+```bash
+# Copy engine into your project
+cp -r styleseed/engine/* your-project/
+
+# Or just point Claude at the repo
+# "Refer to https://github.com/bitjaru/styleseed — read engine/CLAUDE.md and DESIGN-LANGUAGE.md"
+```
+
+## Includes
+
+- 69 visual design rules (brand-agnostic)
+- 48 React components (shadcn-style, Tailwind CSS v4 + Radix UI)
+- 11 slash commands (`/ss-page`, `/ss-review`, `/ss-audit`, `/ss-lint`, etc.)
+- Swappable brand skins (Toss, Stripe, Linear, Vercel, Notion, Raycast, Arc)
+
+## Links
+
+- **Repository:** https://github.com/bitjaru/styleseed
+- **Live demo:** https://styleseed-demo.vercel.app
+- **License:** MIT


### PR DESCRIPTION
Adding StyleSeed to the Skills section.

| [StyleSeed](https://github.com/bitjaru/styleseed) | `skills/styleseed/` | Design judgment: 69 visual rules, brand skins, professional UI |

**What it is:** Design judgment engine that teaches Claude Code the invisible rules pro designers carry — not more design data, but design *judgment*. 69 rules organized into 6 categories (color discipline, spatial rhythm, information hierarchy, shadow/elevation, component variance, motion/feedback).

**Community traction:**
- 300+ GitHub stars, 37 forks in 2 weeks
- oosmetrics Frontend Top 6 (acceleration ranking)
- Merged into bradtraversy/design-resources-for-developers
- Live demo: https://styleseed-demo.vercel.app

**Files added:**
- `skills/styleseed/SKILL.md` — skill definition with quick start
- `README.md` — added row to skills table

MIT licensed, no telemetry, no network calls.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added StyleSeed skill module: a design judgment engine featuring 69 visual rules, 48 React components built with modern frameworks, 11 slash commands, and swappable brand skins for consistent, professional UI development.

* **Documentation**
  * Added StyleSeed skill documentation with quick start instructions and live demo reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->