### PR TITLE
fix(hooks): validate file_path stays within project directory

### DIFF
--- a/hooks/scripts/auto-test.js
+++ b/hooks/scripts/auto-test.js
@@ -5,6 +5,7 @@ const fs = require("fs");
 const input = JSON.parse(process.argv[2] || "{}");
 const filePath = input.file_path || input.filePath || "";
 if (!filePath) process.exit(0);
+if (!path.resolve(filePath).startsWith(path.resolve(process.cwd()))) process.exit(0);
 
 const ext = path.extname(filePath).toLowerCase();
 if (![".ts", ".tsx", ".js", ".jsx", ".py", ".go", ".rs"].includes(ext)) process.exit(0);

--- a/hooks/scripts/lint-fix.js
+++ b/hooks/scripts/lint-fix.js
@@ -4,6 +4,7 @@ const path = require("path");
 const input = JSON.parse(process.argv[2] || "{}");
 const filePath = input.file_path || input.filePath || "";
 if (!filePath) process.exit(0);
+if (!path.resolve(filePath).startsWith(path.resolve(process.cwd()))) process.exit(0);
 
 const ext = path.extname(filePath).toLowerCase();
 

--- a/hooks/scripts/post-edit-check.js
+++ b/hooks/scripts/post-edit-check.js
@@ -4,6 +4,7 @@ const path = require("path");
 const input = JSON.parse(process.argv[2] || "{}");
 const filePath = input.file_path || input.filePath || "";
 if (!filePath) process.exit(0);
+if (!path.resolve(filePath).startsWith(path.resolve(process.cwd()))) process.exit(0);
 
 const ext = path.extname(filePath).toLowerCase();
 const lintCommands = {


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Security Finding (Medium)

`auto-test.js`, `post-edit-check.js`, and `lint-fix.js` all receive a `file_path` from Claude Code hook input and pass it directly as an argument to `execFileSync`. Although array args (not shell interpolation) prevent classic shell injection, a crafted path that escapes the project root — such as `../../some/other/dir/file.ts` — could cause the hooks to run test or lint tools against unintended files outside the repository.

**Risk assessment:** Low in practice (Claude Code generates paths, not untrusted users), but worth closing since the fix is trivial and the hooks fire on every Write/Edit event.

## Fix

One guard line added to each of the three affected scripts, immediately after the existing empty-path check:

```js
if (!path.resolve(filePath).startsWith(path.resolve(process.cwd()))) process.exit(0);
```

If the resolved path is outside `process.cwd()` the script exits silently — identical behaviour to the no-op path for unsupported file extensions. No logic changes otherwise.

**Files changed:**
- `hooks/scripts/auto-test.js` (+1 line)
- `hooks/scripts/post-edit-check.js` (+1 line)
- `hooks/scripts/lint-fix.js` (+1 line)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added path safety validation to development hook scripts to prevent execution on files located outside the project directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->