### PR TITLE
fix(hooks): verify tmux socket exists before trusting TMUX env var

### DIFF
--- a/hooks/scripts/block-dev-server.js
+++ b/hooks/scripts/block-dev-server.js
@@ -1,3 +1,5 @@
+const fs = require("fs");
+
 const input = JSON.parse(process.argv[2] || "{}");
 const command = (input.command || "").toLowerCase();
 
@@ -24,7 +26,8 @@ if (!isDevServer) {
   process.exit(0);
 }
 
-const inTmux = !!process.env.TMUX;
+const tmuxVal = process.env.TMUX || "";
+const inTmux = tmuxVal !== "" && fs.existsSync(tmuxVal.split(",")[0]);
 const inScreen = !!process.env.STY;
 
 if (!inTmux && !inScreen) {


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Security Finding (Low)

`hooks/scripts/block-dev-server.js` guards dev-server commands (e.g. `npm run dev`, `vite`) by checking whether `process.env.TMUX` or `process.env.STY` is set. The intent is to require users to be inside a terminal multiplexer so the dev server won't become an orphaned process.

The issue: `TMUX` is just an environment variable. Any process — or a user typing `export TMUX=fake` — can set it without actually being inside tmux, bypassing the guard entirely.

## Fix

`TMUX`, when set by tmux itself, contains the socket path followed by server PID and session ID, comma-separated (e.g. `/tmp/tmux-1000/default,23456,0`). The socket is a real file on disk. We verify it exists:

```js
// Before
const inTmux = !!process.env.TMUX;

// After
const tmuxVal = process.env.TMUX || "";
const inTmux = tmuxVal !== "" && fs.existsSync(tmuxVal.split(",")[0]);
```

If the env var is set but no socket file exists at that path, `inTmux` is `false` — the guard holds. Legitimate tmux sessions are unaffected.

**Files changed:**
- `hooks/scripts/block-dev-server.js` (+3 lines, -1 line)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved development server detection logic for enhanced reliability in specific development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->