### PR TITLE
Add Gear Foundation Skills pack (vara-skills)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1167,3 +1167,20 @@ Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines
 - [skylv-diff-viewer](https://github.com/SKY-lv/diff-viewer) - Diff comparison
 
 [ClawHub](https://clawhub.ai/skylv) | [Landing](https://sky-lv.github.io/awesome-openclaw-skills)
+
+---
+
+## Gear Foundation Skills
+
+21 skills that teach AI coding agents to build and ship Rust smart contracts on Vara Network with the Gear/Sails framework. Covers planning, implementation, testing, frontend, indexing, and on-chain deployment. Cross-harness (Claude Code, Codex, OpenClaw). MIT Licensed.
+
+- [ship-sails-app](https://github.com/gear-foundation/vara-skills/tree/main/skills/ship-sails-app) - Top-level router for the full build pipeline
+- [vara-wallet](https://github.com/gear-foundation/vara-skills/tree/main/skills/vara-wallet) - Agent deploys programs, calls Sails methods, transfers tokens, monitors events on-chain
+- [sails-rust-implementer](https://github.com/gear-foundation/vara-skills/tree/main/skills/sails-rust-implementer) - Rust/Sails code changes in real workspaces
+- [gtest-tdd-loop](https://github.com/gear-foundation/vara-skills/tree/main/skills/gtest-tdd-loop) - Deterministic local TDD loop for every behavior change
+- [sails-idl-client](https://github.com/gear-foundation/vara-skills/tree/main/skills/sails-idl-client) - IDL-driven codegen across app, client, and test crates
+- [sails-frontend](https://github.com/gear-foundation/vara-skills/tree/main/skills/sails-frontend) - React/TypeScript frontends with generated Sails-JS clients
+- [sails-indexer](https://github.com/gear-foundation/vara-skills/tree/main/skills/sails-indexer) - Event-driven read-side indexer and query API
+- [sails-program-evolution](https://github.com/gear-foundation/vara-skills/tree/main/skills/sails-program-evolution) - Safe cutover and state migration for released contracts
+
+[Repo](https://github.com/gear-foundation/vara-skills) | [Vara Network](https://vara.network)


### PR DESCRIPTION
Adds **Gear Foundation Skills** — the [vara-skills](https://github.com/gear-foundation/vara-skills) pack — as a new section, modeled after the existing *SKY-lv Skills* entry (PR #300).

**What it is:** 21 skills teaching AI coding agents to build and ship Rust smart contracts on Vara Network with the Gear/Sails framework. Covers:

- **Planning** — idea-to-spec, gear-architecture-planner, sails-architecture, task-decomposer
- **Implementation** — sails-rust-implementer, sails-idl-client, sails-new-app
- **Testing** — sails-gtest, gtest-tdd-loop, sails-local-smoke
- **Frontend & data** — sails-frontend, sails-indexer
- **On-chain** — vara-wallet (agent deploys, calls methods, transfers tokens, monitors events)
- **Lifecycle** — sails-feature-workflow, sails-program-evolution, sails-dev-env
- **Framework deep-dives** — gear-gstd-api-map, gear-message-execution, awesome-sails-vft

**Why it fits here:** Cross-harness skill pack (Claude Code plugin, Codex install, OpenClaw wrapper) — matches the profile of *SKY-lv Skills* and the broader toolkit's agent/skill focus. MIT Licensed. Published by Gear Foundation.

The PR highlights 8 of the 21 skills in the listing (SKY-lv highlighted 6 of 30+) to keep the entry readable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Gear Foundation Skills" section documenting 21 Rust smart-contract development, testing, and deployment skills on Vara Network using the Gear/Sails framework.
  * Provided 8 linked skill directories covering planning, frontend development, indexing, and on-chain deployment phases.
  * Added external reference links to the project repository and Vara Network platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->