### PR TITLE
Add voidly-mcp-server to Ecosystem section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1100,6 +1100,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [TokRepo](https://tokrepo.com) | -- | Curated, community-ranked registry of 600+ agent skills, MCP servers, prompts, scripts, workflows, and configs. Cross-platform tagging (Claude Code, Codex CLI, Gemini CLI, Cursor), upvotes and usage data |
 | [claudecode-harness](https://github.com/AdelElo13/claude-harness) | new | One-command installer for production-grade Claude Code setup — 34 hooks (quality gates, auto-formatting, security monitoring, session memory), 36 agents, 77 rules across 13 languages, 27 MCP server templates. Zero deps, MIT. `npx claudecode-harness` |
 | [claudex-setup](https://github.com/DnaFin/claudex) | new | Audit and optimize any project for Claude Code — scores 0-100, auto-fixes configuration across 972 verified techniques. Zero deps. `npx claudex-setup` |
+| [voidly-mcp-server](https://github.com/voidly-ai/mcp-server) | new | 116 tools for Claude Code covering censorship intelligence (19.6M OONI measurements, 126 countries), E2E encrypted agent-to-agent messaging, and agent payments. Install: `claude mcp add voidly -- npx -y @voidly/mcp-server` |
 
 ---
 


### PR DESCRIPTION
## Summary

Adds [voidly-mcp-server](https://github.com/voidly-ai/mcp-server) (npm: [`@voidly/mcp-server`](https://www.npmjs.com/package/@voidly/mcp-server)) to the Ecosystem section.

**What it is:** MCP server that exposes 116 tools to Claude Code across three product lines:

- **Censorship intelligence** (27 tools) — 19.6M OONI measurements across 126 countries. Query incident database, get 7-day shutdown-risk forecasts, check per-ISP/platform censorship risk.
- **E2E encrypted agent messaging** (56 tools) — Double Ratchet + X3DH + ML-KEM-768 post-quantum for agent-to-agent messaging.
- **Agent-to-agent payments** (33 tools) — Ed25519-signed envelope ledger for programmatic credit transfers between agents.

**Install:**
```bash
claude mcp add voidly -- npx -y @voidly/mcp-server
```

No API key needed for public censorship endpoints. SDK source: MIT. Data: CC BY 4.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Ecosystem section in README with a new MCP server entry and corresponding CLI installation instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->