### PR TITLE
Add Emdash Skills to Community Skills section

### DIFF
--- a/README.md
+++ b/README.md
@@ -633,6 +633,7 @@ Thirty-five curated skill modules included in this repo, with access to **400,00
 | [Coware](https://github.com/shitianfang/coware-skills) | `npx skills add shitianfang/coware-skills` | Syncs shared API specs across AI coding agents — prevents merge conflicts from mismatched interfaces, field names, or return types. Auto-pulls latest specs, walks agents through setup for new projects |
 | [humanize-chinese](https://github.com/voidborne-d/humanize-chinese) | `clawhub install humanize-chinese` | Detects and rewrites AI-generated Chinese text. Two-layer detection (20+ rule dimensions + N-gram perplexity), 0-100 scoring, 7 style transforms, academic paper AIGC reduction. 4 slash commands: /detect, /humanize, /academic, /style |
 | [BeHuman](https://github.com/voidborne-d/behuman) | `clawhub install behuman` | Adds inner dialogue to AI responses via Self-Mirror consciousness loop — Self generates instinctive response, Mirror exposes filler/performative empathy, Self revises into real human reply. Based on Lacan's Mirror Stage, Kahneman's Dual Process Theory. MIT |
+| [Emdash Skills](https://github.com/megabytespace/claude-skills) | `git clone https://github.com/megabytespace/claude-skills ~/.claude/skills/emdash-skills` | 14-category autonomous product-building OS for AI coding tools. 94 reference docs, 18 agents. One-line prompts to deployed products on Cloudflare Workers |
 
 ### Installing Skills
 


### PR DESCRIPTION
## Summary

Adds [Emdash Skills](https://github.com/megabytespace/claude-skills) to the Community Skills table.

- **Name:** Emdash Skills
- **URL:** https://github.com/megabytespace/claude-skills
- **Install:** `git clone https://github.com/megabytespace/claude-skills ~/.claude/skills/emdash-skills`
- **Description:** 14-category autonomous product-building OS for AI coding tools. 94 reference docs, 18 agents. One-line prompts to deployed products on Cloudflare Workers.

The entry follows the existing table format with Name | Install | Description columns.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Emdash Skills entry to the Community Skills section in the README, including repository link and installation instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->