### PR TITLE
Add active-listening: preference detection across sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -633,6 +633,7 @@ Thirty-five curated skill modules included in this repo, with access to **400,00
 | [Coware](https://github.com/shitianfang/coware-skills) | `npx skills add shitianfang/coware-skills` | Syncs shared API specs across AI coding agents — prevents merge conflicts from mismatched interfaces, field names, or return types. Auto-pulls latest specs, walks agents through setup for new projects |
 | [humanize-chinese](https://github.com/voidborne-d/humanize-chinese) | `clawhub install humanize-chinese` | Detects and rewrites AI-generated Chinese text. Two-layer detection (20+ rule dimensions + N-gram perplexity), 0-100 scoring, 7 style transforms, academic paper AIGC reduction. 4 slash commands: /detect, /humanize, /academic, /style |
 | [BeHuman](https://github.com/voidborne-d/behuman) | `clawhub install behuman` | Adds inner dialogue to AI responses via Self-Mirror consciousness loop — Self generates instinctive response, Mirror exposes filler/performative empathy, Self revises into real human reply. Based on Lacan's Mirror Stage, Kahneman's Dual Process Theory. MIT |
+| [active-listening](https://github.com/josharsh/active-listening) | `/plugin marketplace add https://github.com/josharsh/active-listening` | Detect developer preferences during conversation ("never push without asking", "always use const") and remember them across sessions. Auto-saves to disk and re-applies in every future conversation |
 
 ### Installing Skills
 


### PR DESCRIPTION
## What is this skill?

[active-listening](https://github.com/josharsh/active-listening) detects developer preference statements during conversation and persists them to disk. Say things like "never push without asking" or "always use const" — it saves them and re-applies in every future session.

## Features

- **Auto-detection** of high-confidence patterns: "Never...", "Always...", "Remember:...", "From now on...", "Don't..."
- **Confirmation** for medium-confidence patterns: "I prefer...", "I like to..."
- **Smart ignoring** of past tense, questions, and hypotheticals
- **Categorized storage** (Git, Coding Style, Project Config, Testing, Communication, Architecture)
- **Management commands**: show, forget, clear, status
- **Plugin marketplace format** with marketplace.json
- **8 behavioral tests** (skillmother-compatible)

## Install

\`\`\`
/plugin marketplace add https://github.com/josharsh/active-listening
\`\`\`

## Checklist

- [x] Public GitHub repo
- [x] SKILL.md with frontmatter
- [x] README with documentation
- [x] MIT License
- [x] Tests included
- [x] Plugin marketplace format

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added information about the active-listening skill to the README, which detects and auto-saves developer preferences during conversations for reuse in future sessions via the plugin marketplace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->