### PR TITLE
Add Agent Sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -982,6 +982,7 @@ claude-code-toolkit/               850+ files
 | [ccswarm](https://github.com/nwiizo/ccswarm) | 127 | Rust-based multi-agent orchestration with specialized agent pools, Git worktree isolation, 93% token reduction |
 | [parallel-code](https://github.com/johannesjo/parallel-code) | 370+ | Run Claude Code, Codex, and Gemini side by side -- each in its own git worktree |
 | [Bernstein](https://github.com/chernistry/bernstein) | 5+ | Python multi-agent orchestrator — spawns Claude Code, Codex CLI, and Gemini CLI in parallel on isolated git worktrees, verifies with tests, auto-commits. Zero LLM tokens on coordination |
+| [Agent Sessions](https://github.com/jazzyalex/agent-sessions) | 495+ | Native macOS app to search, browse, and resume Claude Code, Codex, Gemini CLI, OpenCode, and other local agent sessions, with Agent Cockpit live iTerm2 orchestration |
 | [Poirot](https://github.com/LeonardoCardoso/Poirot) | 96 | macOS app for browsing Claude Code sessions, viewing diffs, and re-running commands. Reads local transcripts, runs offline |
 | [TokenEater](https://github.com/AThevon/TokenEater) | 179 | Native macOS menu bar app for monitoring Claude AI usage limits and watching coding sessions live |
 | [Claw](https://github.com/jamesrochabrun/Claw) | 86 | Native macOS app wrapping Claude Code SDK in Swift. Plan Mode, MCP Integration, Custom System Prompts |


### PR DESCRIPTION
Adds Agent Sessions to Companion Apps & GUIs.

Why it fits:
- Native macOS app for searching, browsing, and resuming local Claude Code sessions.
- Also supports Codex, Gemini CLI, OpenCode, and other coding-agent histories.
- Includes Agent Cockpit for live iTerm2 orchestration of active local agent sessions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Agent Sessions to the companion apps and GUIs reference, a macOS application for browsing and resuming AI-assisted coding sessions across multiple platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->