### PR TITLE
Add logic-lens; update brooks-lint description to v1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Over 176 production-ready plugins that extend Claude Code with domain-specific c
 | [backend-architect](plugins/backend-architect/) | Backend service architecture design with endpoint scaffolding |
 | [bug-detective](plugins/bug-detective/) | Debug issues systematically with root cause analysis and execution tracing |
 | [Bouncer](https://github.com/buildingopen/bouncer) | Independent quality gate that uses Gemini to audit Claude Code's output. Includes Stop hook (automatic), quick audit skill, and deep audit with full tool access. One-liner install. |
-| [brooks-lint](https://github.com/hyhmrright/brooks-lint) | AI code reviews grounded in six classic engineering books (Brooks, Fowler, Martin, McConnell, Hunt & Thomas, Evans). Diagnoses code across 6 decay risk dimensions with structured findings (Symptom → Source → Consequence → Remedy). Supports PR review, architecture audit, tech debt assessment, and test quality review. v0.6 adds Mermaid dependency graphs. |
+| [brooks-lint](https://github.com/hyhmrright/brooks-lint) | AI code reviews grounded in twelve classic engineering books. Diagnoses code across 6 production + 6 test decay risks with structured findings (Symptom → Source → Consequence → Remedy). Six modes: PR Review, Architecture Audit, Tech Debt, Test Quality Review, Health Dashboard, Full Sweep. v1.2. |
 | [ccmanager](https://github.com/kbwo/ccmanager) | Coding agent session manager supporting Claude Code, Gemini CLI, Codex, Cursor, Copilot, Cline, OpenCode, Kimi CLI. Smart auto-approval via Haiku, devcontainer support. 940+ stars |
 | [ccpm](https://github.com/automazeio/ccpm) | Project management using GitHub Issues + Git worktrees for parallel agent execution. Issue-analyze, epic-start, epic-merge commands. 7,600+ stars |
 | [ccusage](https://github.com/ryoppippi/ccusage) | CLI for analyzing Claude Code/Codex usage from local JSONL files. Daily, monthly, session, billing-window reports. Offline, zero API calls. 11,500+ stars |
@@ -209,6 +209,7 @@ Over 176 production-ready plugins that extend Claude Code with domain-specific c
 | [lightcms](https://github.com/jonradoff/lightcms) | AI-native CMS with 41 MCP tools for managing websites through natural language — pages, templates, assets, themes, collections, redirects, and more with full content versioning |
 | [linear-helper](plugins/linear-helper/) | Linear issue tracking integration and workflow management |
 | [load-tester](plugins/load-tester/) | Load and stress testing for APIs and web services |
+| [logic-lens](https://github.com/hyhmrright/logic-lens) | Logic-first code review plugin for Claude Code — detects behavioral bugs via semi-formal execution tracing. Finds logic errors linters and type checkers miss. Structured findings: Premises → Trace → Divergence → Remedy with L1–L6 risk codes. Six skills: logic-review, logic-explain, logic-diff, logic-locate, logic-health, logic-fix-all. |
 | [memory-profiler](plugins/memory-profiler/) | Memory leak detection and heap analysis |
 | [migrate-tool](plugins/migrate-tool/) | Generate database migrations and code migration scripts for framework upgrades |
 | [migration-generator](plugins/migration-generator/) | Database migration generation and rollback management |


### PR DESCRIPTION
## Changes

### Add logic-lens (new entry)

Logic-first code review plugin for Claude Code that detects behavioral bugs via semi-formal execution tracing.

- **Repo:** https://github.com/hyhmrright/logic-lens
- **What it finds:** Logic errors that linters and type checkers miss — off-by-one errors, wrong predicate conditions, incorrect state transitions, unreachable branches
- **Finding format:** Premises → Trace → Divergence → Remedy (with L1–L6 risk codes)
- **Six skills:** logic-review, logic-explain, logic-diff, logic-locate, logic-health, logic-fix-all
- **Platforms:** Claude Code plugin + Gemini CLI extension + Codex CLI

### Update brooks-lint (existing entry)

brooks-lint has expanded from 6 books to 12 books and added two new modes (Health Dashboard + Full Sweep) since it was first listed. Updated description reflects current v1.2 state.

- Six classic → twelve classic engineering books
- 6 decay dimensions → 6 production + 6 test decay risks  
- Four modes → Six modes (added Health Dashboard and Full Sweep)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated brooks-lint plugin documentation with expanded coverage scope and enhanced risk model with 12 categories
  * Added new logic-lens plugin for structured code review with risk classification system
  * Updated version to v1.2

<!-- end of auto-generated comment: release notes by coderabbit.ai -->