### PR TITLE
Add KubeStellar Console MCP server to Kubernetes config

### DIFF
--- a/README.md
+++ b/README.md
@@ -880,7 +880,7 @@ cp templates/claude-md/standard.md CLAUDE.md
 
 ## MCP Configs
 
-Thirteen curated Model Context Protocol server configurations.
+Fourteen curated Model Context Protocol server configurations.
 
 | Config | File | Servers Included |
 |--------|------|-----------------|

--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Over 176 production-ready plugins that extend Claude Code with domain-specific c
 | [infrastructure-maintainer](plugins/infrastructure-maintainer/) | Infrastructure maintenance with security audits and update management |
 | [ios-developer](plugins/ios-developer/) | iOS and Swift development with SwiftUI views and models |
 | [k8s-helper](plugins/k8s-helper/) | Generate Kubernetes manifests and debug pod issues with kubectl |
+| [kubestellar-console](https://github.com/kubestellar/console) | Multi-cluster Kubernetes dashboard with built-in MCP server for AI agents — manage workloads, policies, RBAC, and compliance across clusters. 50+ dashboard cards, real-time WebSocket streaming, and Claude/Copilot integration via kc-agent. |
 | [leapfrog-mcp](https://github.com/anthonybono21-cloud/leapfrog) | Multi-session browser MCP server -- 15 parallel isolated Chromium sessions so multiple Claude Code terminals can browse simultaneously. 37 tools for navigation, extraction, interaction, network interception, and session profiles. 797 tests. Install: `npx -y leapfrog-mcp` |
 | [license-checker](plugins/license-checker/) | License compliance checking and NOTICE file generation |
 | [lighthouse-runner](plugins/lighthouse-runner/) | Run Lighthouse audits and fix performance issues |
@@ -885,7 +886,7 @@ Thirteen curated Model Context Protocol server configurations.
 |--------|------|-----------------|
 | Recommended | [`recommended.json`](mcp-configs/recommended.json) | 14 essential servers for general development |
 | Full Stack | [`fullstack.json`](mcp-configs/fullstack.json) | Filesystem, GitHub, Postgres, Redis, Puppeteer |
-| Kubernetes | [`kubernetes.json`](mcp-configs/kubernetes.json) | kubectl-mcp-server, Docker, GitHub |
+| Kubernetes | [`kubernetes.json`](mcp-configs/kubernetes.json) | kubectl-mcp-server, KubeStellar Console, Docker, GitHub |
 | Data Science | [`data-science.json`](mcp-configs/data-science.json) | Jupyter, SQLite, PostgreSQL, Filesystem |
 | Frontend | [`frontend.json`](mcp-configs/frontend.json) | Puppeteer, Figma, Storybook |
 | Crypto / DeFi | [`crypto-defi.json`](mcp-configs/crypto-defi.json) | defi-mcp, Filesystem, Fetch, Memory |

--- a/mcp-configs/kubernetes.json
+++ b/mcp-configs/kubernetes.json
@@ -10,6 +10,11 @@
       "args": ["-y", "kubectl-mcp-app"],
       "description": "8 interactive UI dashboards for Kubernetes: pods, logs, deployments, helm, cluster, cost, events, network."
     },
+    "kubestellar-console": {
+      "command": "go",
+      "args": ["run", "github.com/kubestellar/console/cmd/kc-agent@latest"],
+      "description": "Multi-cluster Kubernetes MCP bridge: manage workloads, policies, RBAC, and compliance across clusters via KubeStellar Console."
+    },
     "docker": {
       "command": "npx",
       "args": ["-y", "@modelcontextprotocol/server-docker"],

--- a/mcp-configs/kubernetes.json
+++ b/mcp-configs/kubernetes.json
@@ -2,27 +2,42 @@
   "mcpServers": {
     "kubectl": {
       "command": "uvx",
-      "args": ["kubectl-mcp-server"],
+      "args": [
+        "kubectl-mcp-server"
+      ],
       "description": "270+ Kubernetes management tools: pods, deployments, services, helm, networking, RBAC, and cluster operations."
     },
     "kubectl-app": {
       "command": "npx",
-      "args": ["-y", "kubectl-mcp-app"],
+      "args": [
+        "-y",
+        "kubectl-mcp-app"
+      ],
       "description": "8 interactive UI dashboards for Kubernetes: pods, logs, deployments, helm, cluster, cost, events, network."
     },
     "kubestellar-console": {
-      "command": "go",
-      "args": ["run", "github.com/kubestellar/console/cmd/kc-agent@latest"],
-      "description": "Multi-cluster Kubernetes MCP bridge: manage workloads, policies, RBAC, and compliance across clusters via KubeStellar Console."
+      "command": "kc-agent",
+      "args": [],
+      "env": {
+        "KC_ALLOWED_ORIGINS": "http://localhost:5174",
+        "KC_AGENT_TOKEN": "<your-agent-token>"
+      },
+      "description": "Multi-cluster Kubernetes MCP bridge: manage workloads, policies, RBAC, and compliance across clusters via KubeStellar Console. Install: brew tap kubestellar/tap && brew install kc-agent (uses ~/.kube/config by default)."
     },
     "docker": {
       "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-docker"],
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-docker"
+      ],
       "description": "Manage Docker containers, images, volumes, and networks for local development and testing."
     },
     "github": {
       "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-github"],
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-github"
+      ],
       "env": {
         "GITHUB_PERSONAL_ACCESS_TOKEN": "<your-github-pat>"
       },
@@ -30,12 +45,19 @@
     },
     "filesystem": {
       "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/path/to/k8s-manifests"],
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "/path/to/k8s-manifests"
+      ],
       "description": "Read and write Kubernetes YAML manifests, Helm values files, and Dockerfiles."
     },
     "memory": {
       "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-memory"],
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-memory"
+      ],
       "description": "Track cluster topology, resource relationships, and deployment decisions across sessions."
     }
   }


### PR DESCRIPTION
Adds [KubeStellar Console](https://github.com/kubestellar/console) to the Kubernetes MCP config and All Plugins table.

## What is KubeStellar Console?

KubeStellar Console is an open-source multi-cluster Kubernetes dashboard with a built-in MCP server (**kc-agent**) that bridges AI agents to Kubernetes clusters. It provides:

- **50+ dashboard cards** — cluster health, workloads, RBAC, compliance, CI/CD, AI/ML ops
- **Multi-cluster management** — manage workloads and policies across clusters via KubeStellar
- **MCP server (kc-agent)** — enables Claude, Copilot, and other AI agents to interact with Kubernetes clusters
- **Real-time WebSocket streaming** — live updates from clusters
- **CNCF KubeStellar ecosystem** — part of the KubeStellar project (CNCF Sandbox)

## Changes

1. **`mcp-configs/kubernetes.json`** — Added `kubestellar-console` MCP server entry
2. **`README.md`** — Added entry to All Plugins table and updated Kubernetes MCP config description

The MCP server runs via `go run github.com/kubestellar/console/cmd/kc-agent@latest` and bridges Claude Code to your kubeconfig clusters for managing workloads, policies, RBAC, and compliance.

Live demo: [console.kubestellar.io](https://console.kubestellar.io)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added KubeStellar Console plugin providing a multi-cluster Kubernetes dashboard with built-in MCP server support for managing workloads, policies, RBAC, and compliance.

* **Documentation**
  * Updated README and MCP configuration listings to include KubeStellar Console, add one curated MCP configuration, and show the console alongside existing Kubernetes MCP servers in the "Servers Included" list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->