### PR TITLE
Add weft to plugins table

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,7 @@ Over 176 production-ready plugins that extend Claude Code with domain-specific c
 | [Clarvia MCP](https://github.com/clarvia-project/scanner) | MCP quality scanner — scans any MCP server, returns AEO (Agent Engine Optimization) score. Indexes 27,843+ tools for instant lookup. 24 MCP tools (search, scan, compare, leaderboard, trending). `npx -y clarvia-mcp-server` |
 | [OraClaw](https://github.com/Whatsonyourmind/oraclaw) | Decision intelligence MCP server — 12 tools with 19 ML algorithms (multi-armed bandits, constraint solvers, forecasters, risk models, Q-learning, A*, simulated annealing). Sub-25ms responses, deterministic, 945 tests. `npx @oraclaw/mcp-server` |
 | [US Business Data MCP](https://github.com/avabuildsdata/mcp-us-business-data) | MCP server for US business data — search entities across 17 state Secretary of State databases, YellowPages leads, building permits from 47 cities, 20+ federal APIs (SEC, FDA, FEMA). Built in Go, on MCP Registry |
+| [weft](https://github.com/dioptx/weft) | Deterministic workflow tracking with event-sourced state — templates with skill chains, bounded loops, and per-step tool guards. Hooks block out-of-order tool calls; state survives compaction via an append-only event log. Stdlib-only Python core, 191 tests, MIT. Install: `/plugin marketplace add dioptx/weft` |
 
 ### Installing a Plugin
 


### PR DESCRIPTION
Adds [dioptx/weft](https://github.com/dioptx/weft) to the All Plugins table.

Weft is a Claude Code plugin for deterministic workflow tracking. Templates declare ordered steps with skill bindings, bounded loops, and per-step tool guards. Four hooks (`SessionStart`, `PreToolUse`, `PreCompact`, `Stop`) enforce the contract — out-of-order tool calls are blocked, premature session exits are refused, and state survives compaction via an append-only event log.

- 11 slash commands (`/wf-*`, `/ev-query`)
- 4 hooks
- Event-sourced state (`.claude/weft/events.jsonl`) — fully reconstructible via `/wf-rebuild`
- 191 tests passing, MIT licensed, Python stdlib only

The README has 5 reproducible asciinema GIFs covering structural preview, first run, custom workflow authoring, skill extension, and event-log rebuild. Recording scripts in `docs/demos/` drive the real CLI in mktemp scratch dirs.

Install: `/plugin marketplace add dioptx/weft`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the weft plugin, including installation instructions and repository information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->