### PR TITLE
Add Drevon - Mac GTM agent desktop app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1013,6 +1013,8 @@ claude-code-toolkit/               850+ files
 
 ---
 
+- [Drevon](https://drevon.dev) - Mac desktop workspace for GTM engineers. Run parallel AI agents powered by Claude Code, Codex, or Copilot to build target lists, score accounts, and pull prospect intel.
+
 ## Ecosystem
 
 Notable projects, directories, and resources across the Claude Code ecosystem.


### PR DESCRIPTION
Adding [Drevon](https://drevon.dev) to this list.

Drevon is a Mac desktop workspace for GTM engineers. Run parallel AI agents powered by Claude Code, Codex, or Copilot to build target lists, score accounts, and pull prospect intel from LinkedIn, CRM, and sales tools.

Website: https://drevon.dev

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README to include information about Drevon, a Mac desktop workspace for GTM engineers featuring parallel AI agent execution for building target lists, scoring accounts, and pulling prospect intel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->