### PR TITLE
Add debian-packaging-agent-skill to All Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Over 176 production-ready plugins that extend Claude Code with domain-specific c
 | [data-privacy](plugins/data-privacy/) | Data privacy implementation with PII detection and anonymization |
 | [database-optimizer](plugins/database-optimizer/) | Database query optimization with index recommendations and EXPLAIN analysis |
 | [dead-code-finder](plugins/dead-code-finder/) | Find and remove dead code across the codebase |
+| [debian-packaging-agent-skill](https://github.com/cosgroveb/debian-packaging-agent-skill) | Debian packaging skill covering debhelper, debian/rules, package metadata, lintian, and multi-binary packages for Ruby (gem2deb), Python (pybuild), Rust (debcargo), and Go (dh-golang). Loads language-specific reference docs on demand. Apache 2.0 |
 | [debug-session](plugins/debug-session/) | Interactive debugging workflow with git bisect integration |
 | [dig2crawl](https://github.com/ZENG3LD/dig2crawl) | Universal web crawler with Claude-powered CSS selector discovery. 4-level AI extraction escalation (CSS, browser actions, Claude Vision, captcha). Rust. |
 | [dependency-manager](plugins/dependency-manager/) | Audit, update, and manage project dependencies with safety checks |


### PR DESCRIPTION
Adds [debian-packaging-agent-skill](https://github.com/cosgroveb/debian-packaging-agent-skill) to the **All Plugins** table.

debian-packaging-agent-skill is a Claude Code plugin for building .deb packages. It covers debhelper, debian/rules, package metadata, lintian, and multi-binary packages for Ruby (gem2deb), Python (pybuild), Rust (debcargo), and Go (dh-golang). The skill loads language-specific reference docs on demand based on which language it detects in the project. Apache 2.0.

Install:

```
/plugin marketplace add cosgroveb/debian-packaging-agent-skill
/plugin install debian-packaging-agent-skill@cosgroveb-debian-packaging-agent-skill
```

Format matches existing entries in the All Plugins table.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded plugin catalog with the addition of `debian-packaging-agent-skill`, a new Debian packaging-focused agent skill featuring Apache 2.0 licensing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->