### PR TITLE
Add repo-visuals plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,7 @@ Over 176 production-ready plugins that extend Claude Code with domain-specific c
 | [refactor-engine](plugins/refactor-engine/) | Extract functions, simplify complex code, and reduce cognitive complexity |
 | [regex-builder](plugins/regex-builder/) | Build, test, and debug regular expression patterns |
 | [release-manager](plugins/release-manager/) | Semantic versioning management and automated release workflows |
+| [repo-visuals](https://github.com/livlign/claude-skills/tree/main/plugins/repo-visuals) | Designs bespoke GitHub README hero visuals — animated GIF or static PNG — through a structured discovery dialog. Retina capture via Puppeteer + ffmpeg. Heroes merged into HTMLHint, Terminal.Gui, ast-graph. |
 | [responsive-designer](plugins/responsive-designer/) | Responsive design implementation and testing |
 | [review-squad](https://github.com/2389-research/review-squad) | Multi-perspective code review via dispatched subagent panels: experts, normie users, pedantic nitpickers, and real-user task runners |
 | [schema-designer](plugins/schema-designer/) | Database schema design and ERD generation |


### PR DESCRIPTION
Adds **repo-visuals** to the All Plugins table.

**Plugin:** https://github.com/livlign/claude-skills/tree/main/plugins/repo-visuals

A Claude Code plugin that designs bespoke GitHub README hero visuals — animated GIF or static PNG — through a structured discovery dialog. Scans the repo, recommends a format that fits its identity (terminal demo, product UI, brand wordmark, banner, diagram-as-hero), generates tailored HTML, previews in-browser, and exports retina-quality artifacts via Puppeteer + ffmpeg.

Heroes shipped with the plugin have already merged upstream into:
- [HTMLHint/HTMLHint](https://github.com/htmlhint/HTMLHint)
- [gui-cs/Terminal.Gui](https://github.com/gui-cs/Terminal.Gui)
- [emtyty/ast-graph](https://github.com/emtyty/ast-graph)
- [affaan-m/everything-claude-code](https://github.com/affaan-m/everything-claude-code) (a Claude Code resource list)
- and others (see plugin SHOWCASE.md)

MIT licensed. Manifest passes `claude plugin validate`. Inserted alphabetically between `release-manager` and `responsive-designer`.