### PR TITLE
Add BuyWhere e-commerce MCP server configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Claude Code Toolkit
 
-**The most comprehensive toolkit for Claude Code -- 135 agents, 35 curated skills (+400,000 via [SkillKit](https://agenstskills.com)), 42 commands, 176+ plugins, 20 hooks, 15 rules, 7 templates, 14 MCP configs, 26 companion apps, 53 ecosystem entries, and more.**
+**The most comprehensive toolkit for Claude Code -- 135 agents, 35 curated skills (+400,000 via [SkillKit](https://agenstskills.com)), 42 commands, 176+ plugins, 20 hooks, 15 rules, 7 templates, 15 MCP configs, 26 companion apps, 53 ecosystem entries, and more.**
 
 <p align="center">
   <a href="https://trendshift.io/repositories/21839" target="_blank">
@@ -879,7 +879,7 @@ cp templates/claude-md/standard.md CLAUDE.md
 
 ## MCP Configs
 
-Thirteen curated Model Context Protocol server configurations.
+Fourteen curated Model Context Protocol server configurations.
 
 | Config | File | Servers Included |
 |--------|------|-----------------|
@@ -897,6 +897,7 @@ Thirteen curated Model Context Protocol server configurations.
 | Workflow Automation | [`workflow-automation.json`](mcp-configs/workflow-automation.json) | n8n workflow builder, Pipedream integration |
 | Mobile | [`mobile.json`](mcp-configs/mobile.json) | Android ADB automation, Xcode build tools |
 | Finance | [`finance.json`](mcp-configs/finance.json) | Helium news/markets/options, Chart Library pattern intelligence, Fetch, Memory |
+| E-Commerce | [`ecommerce.json`](mcp-configs/ecommerce.json) | BuyWhere product search, price comparison, deal discovery across 1M+ products |
 
 ---
 

--- a/mcp-configs/ecommerce.json
+++ b/mcp-configs/ecommerce.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "buywhere": {
+      "command": "npx",
+      "args": ["-y", "@buywhere/mcp-server"],
+      "env": {
+        "BUYWHERE_API_KEY": "<your-buywhere-api-key>"
+      },
+      "description": "Agent-native product catalog API for Southeast Asia commerce. Search 1.5M+ products across Shopee, Lazada, Amazon SG, and 50+ merchants. Real-time price comparison, deal discovery, and multi-currency support (SGD, USD, MYR, IDR, THB, PHP, VND). Tools: search_products, get_product, compare_prices, get_deals, browse_categories, get_category_products."
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds BuyWhere MCP Server to the MCP Configs section. BuyWhere is an agent-native product catalog API for Southeast Asia commerce with 6 production-ready tools:

- **search_products** - Full-text product search across 1.5M+ products
- **get_product** - Detailed product information
- **compare_prices** - Cross-merchant price comparison
- **get_deals** - Active promotions and discounts
- **browse_categories** - Category taxonomy browsing
- **get_category_products** - Products by category

**Install:** `npx -y @buywhere/mcp-server`
**Homepage:** https://buywhere.ai
**Free tier:** 1,000 calls/month

### Changes
- Added `mcp-configs/ecommerce.json` with BuyWhere MCP server config
- Added E-Commerce row to the MCP Configs table in README
- Updated header count from 14 to 15 MCP configs
- Updated description from Thirteen to Fourteen

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced E-Commerce MCP server configuration enabling catalog management, product search, price tracking, and deals discovery tools across multiple supported merchants and currencies
  * Added AutoSearch configuration entry

* **Documentation**
  * Updated MCP configuration counts and documentation to reflect new additions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->