### PR TITLE
Add temporal-core: research-backed temporal awareness plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ Over 176 production-ready plugins that extend Claude Code with domain-specific c
 | [smart-commit](plugins/smart-commit/) | Intelligent git commits with conventional format, semantic analysis, and changelog generation |
 | [sprint-prioritizer](plugins/sprint-prioritizer/) | Sprint planning with story prioritization and capacity estimation |
 | [technical-sales](plugins/technical-sales/) | Technical demo creation and POC proposal writing |
+| [temporal-core](https://github.com/Evanyuan-builder/temporal-core) | Make Claude Code agents feel time pass — research-backed temporal awareness via 3 hooks (SessionStart + UserPromptSubmit + PreToolUse) that inject `session elapsed` and `since last action` signals into context. Bundled skill teaches pacing/deadline reasoning. Aher et al. 2026: explicit time surfacing → 6× deadline performance. Apache-2.0, zero runtime deps. |
 | [the-pragmatic-pm](https://github.com/marfoerst/the-pragmatic-pm) | PM leadership toolkit with 43 skills, 5 agents, 4 workflows. Covers PRD generation, OKR lifecycle, pricing, AI pricing, positioning, sales enablement, and quarterly planning. |
 | [terraform-helper](plugins/terraform-helper/) | Terraform module creation and infrastructure planning |
 | [test-data-generator](plugins/test-data-generator/) | Generate realistic test data and seed databases |


### PR DESCRIPTION
## Summary

Adds `temporal-core` to the All Plugins table — a small Apache-2.0 plugin that gives Claude Code agents a sense of time passing within a session.

## What it does

Three hooks inject elapsed-time signals into the agent's context:

- `SessionStart` → records session start timestamp
- `UserPromptSubmit` → injects `[temporal-core] session elapsed: 12m 34s`
- `PreToolUse` → injects `[temporal-core] since last action: 47s`

A bundled `temporal-awareness` skill (SKILL.md) teaches the agent how to use the signals — pacing decisions, deadline-aware prioritization, recency reasoning, honest "how long did this take?" answers.

## Why

Aher et al. (2026), *Real-Time Deadlines Reveal Temporal Awareness Failures in LLM Strategic Dialogues*, found that surfacing remaining time boosted LLM negotiation acceptance odds **6×**. `temporal-core` is the minimal implementation of that finding for Claude Code.

## Verified

- Plugin loads via `claude --plugin-dir` ✓
- `UserPromptSubmit` hook fires and `additionalContext` reaches the agent ✓ (verified in headless `claude -p` session: agent quoted the injected `[temporal-core] session elapsed: 1s` fragment unprompted)
- Apache-2.0, zero runtime deps (just `jq`, gracefully no-ops if missing)

## Repo

- https://github.com/Evanyuan-builder/temporal-core
- v0.1.0 release: https://github.com/Evanyuan-builder/temporal-core/releases/tag/v0.1.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "temporal-core" plugin entry to the plugins catalog, documenting its time-awareness features and available hooks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->