### PR TITLE
Add ToutKit to Companion Apps & GUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1010,6 +1010,7 @@ claude-code-toolkit/               850+ files
 | [cc-token-status](https://github.com/jayson-jia-dev/cc-token-status) | new | macOS menu bar dashboard for Claude Code. Shows live plan limits (5h/7d), costs, tokens, trends, model breakdown, user level system, and multi-machine iCloud sync. 5 languages, dark/light mode. Single Python file, auto-updates |
 | [Watchfire](https://github.com/watchfire-io/watchfire) | 33 | Orchestration platform for AI coding agents (starting with Claude Code). Manages project context, breaks work into tasks, runs agents with full codebase awareness. Git worktree isolation, sandboxed execution, multiple agent modes (chat, task, autonomous). Go daemon + CLI/TUI + Electron GUI |
 | [aby-claude-watcher](https://github.com/aby-agency/aby-claude-watcher) | new | Real-time macOS dashboard for Claude Code sessions. Five color-coded states (thinking, running, waiting, error, completed), per-session notifications, one-click focus terminal across iTerm2/Terminal/Warp/VSCode/Cursor/Ghostty/kitty/WezTerm/Hyper. Bilingual FR/EN, menu-bar tray, MIT licensed. Apple Silicon + Intel builds |
+| [ToutKit](https://github.com/toutkit/toutkit) | new | Desktop notebook for AI CLIs (Claude Code, Codex, Gemini). Pairs a sidebar of notes with a built-in terminal and an in-app webview that renders whatever the AI writes — each note is a self-contained folder with its own SQLite, key/value store, attached files, and scripts, so a note can grow from a static page into a sortable table, dashboard, or research tool. Local-first, AGPL-3.0 |
 
 ---
 


### PR DESCRIPTION
Adds [**ToutKit**](https://github.com/toutkit/toutkit) to the **Companion Apps & GUIs** table.

ToutKit is a desktop notebook for AI CLIs (Claude Code, Codex, Gemini). It pairs a sidebar of notes with a built-in terminal and an in-app webview that renders whatever the AI writes inline — so answers come back as interactive HTML pages instead of walls of text. Each note is a self-contained folder with its own SQLite, key/value store, attached files, and scripts, so a note can grow from a static page into a sortable table, dashboard, or research tool without leaving your filesystem.

- Repo: https://github.com/toutkit/toutkit
- License: AGPL-3.0
- Local-first (no server required); Electron, runs on macOS / Windows / Linux

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added ToutKit to the companion apps list—a desktop notebook application for AI CLIs, featuring a built-in terminal, in-app webview, per-note storage, attachments, and local-first architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->