### PR TITLE
Add cctally to Companion Apps & GUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1010,6 +1010,7 @@ claude-code-toolkit/               850+ files
 | [cc-token-status](https://github.com/jayson-jia-dev/cc-token-status) | new | macOS menu bar dashboard for Claude Code. Shows live plan limits (5h/7d), costs, tokens, trends, model breakdown, user level system, and multi-machine iCloud sync. 5 languages, dark/light mode. Single Python file, auto-updates |
 | [Watchfire](https://github.com/watchfire-io/watchfire) | 33 | Orchestration platform for AI coding agents (starting with Claude Code). Manages project context, breaks work into tasks, runs agents with full codebase awareness. Git worktree isolation, sandboxed execution, multiple agent modes (chat, task, autonomous). Go daemon + CLI/TUI + Electron GUI |
 | [aby-claude-watcher](https://github.com/aby-agency/aby-claude-watcher) | new | Real-time macOS dashboard for Claude Code sessions. Five color-coded states (thinking, running, waiting, error, completed), per-session notifications, one-click focus terminal across iTerm2/Terminal/Warp/VSCode/Cursor/Ghostty/kitty/WezTerm/Hyper. Bilingual FR/EN, menu-bar tray, MIT licensed. Apple Silicon + Intel builds |
+| [cctally](https://github.com/omrikais/cctally) | new | Track Claude Code subscription usage as a weekly $-per-1% trend. Local web dashboard, terminal UI, forecasts, threshold alerts. Apache-2.0, zero telemetry. |
 
 ---
 


### PR DESCRIPTION
Adds [cctally](https://github.com/omrikais/cctally) to **Companion Apps & GUIs**.

cctally tracks Claude Code subscription usage as a weekly **$-per-1% trend**, with a local web dashboard, terminal UI, forecasts, and threshold alerts. It complements ccusage (already listed in this toolkit's Plugins section) by focusing on the **subscription-quota dimension** rather than raw token cost — local-only, no telemetry, Apache-2.0.

**Placement rationale:** Considered both `### All Plugins` (where ccusage lives) and `## Companion Apps & GUIs`. Chose Companion Apps & GUIs because the closest functional peers — **TokenEater**, **WhereMyTokens**, **cc-token-status**, **tokburn**, **claude-usage** — are all there as local usage/cost monitors. The `Plugins` section is broader but the usage-monitoring cluster has clearly settled into Companion Apps & GUIs. Matched the section's 3-column `Name | Stars | Description` format and used `new` for the Stars column (project is 4 days old, 2 ⭐, matches the convention of other recent entries like `Anima`, `Notch So Good`, `telegram-ai-bridge`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added information about a new companion app for tracking Claude Code subscription usage with a local dashboard/terminal UI, including forecasts and alerts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->