### PR TITLE
Add ejentum-mcp under All Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Over 176 production-ready plugins that extend Claude Code with domain-specific c
 
 | Plugin | Description |
 |--------|-------------|
+| [ejentum-mcp](https://github.com/ejentum/ejentum-mcp) | Reasoning Harness for agentic AI: 4 MCP tools (reasoning, code, anti-deception, memory) over 679 engineered cognitive operations. Each call returns a structured scaffold the calling LLM ingests before its first token. Catches sycophancy, hallucination, and reasoning decay before they emerge. Companion `skills/` directory ships SKILL.md files for autonomous routing in Claude Code. MIT, free tier 100 calls. |
 | [agento-patronum](https://github.com/emaarco/agento-patronum) | Protects sensitive files, credentials, and shell commands from unintended AI access via Claude Code hooks. Unlike settings.json deny rules, hooks are an enforcement layer you own and can verify. Ships with defaults for .env files, SSH keys, AWS credentials, and kubeconfig. |
 | [skills-janitor](https://github.com/khendzel/skills-janitor) | Audit, deduplicate, check, fix, and track usage of your Claude Code skills. 9 slash commands, zero dependencies |
 | [great_cto](https://github.com/avelikiy/great_cto) | Full SDLC pipeline plugin with 7 agents (tech-lead, senior-dev, qa-engineer, security-officer, devops, l3-support, project-auditor), 12-angle code review, 10 project archetypes, 13 compliance frameworks (SOC2/HIPAA/PCI-DSS/GDPR/ISO 27001), two-gate approval flow. Opus 4.7 advisor escalation, file-based, MIT |


### PR DESCRIPTION
Adding **ejentum-mcp**, a Reasoning Harness for agentic AI exposed as four MCP tools (harness_reasoning, harness_code, harness_anti_deception, harness_memory) over 679 engineered cognitive operations. Each call returns a structured scaffold the calling LLM ingests before its first token, addressing the four mechanism failures common in long Claude Code sessions: attention decay, reasoning decay, sycophantic collapse, hallucination drift.

Includes a companion `skills/` directory with five SKILL.md files for autonomous routing in Claude Code (one router + four per-mode files). The skills now teach both the native MCP tool call and an HTTP/curl fallback.

Links:
- Source: https://github.com/ejentum/ejentum-mcp (MIT)
- npm: https://www.npmjs.com/package/ejentum-mcp
- Official MCP Registry: io.github.ejentum/ejentum-mcp
- Glama, mcp.so, Smithery, Continue Hub, Cline marketplace
- Free tier: 100 calls

Disclosure: I'm the maintainer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new plugin entry to the "All Plugins" table with repository link and capability descriptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->