### PR TITLE
Add Awesome AI Startups to Related Awesome Lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -1142,6 +1142,7 @@ Tutorials, guides, and deep-dives on Claude Code.
 | [claude-code-best-practice](https://github.com/shanraisshan/claude-code-best-practice) | 25,000+ | Comprehensive reference implementation for Claude Code config |
 | [awesome-claude-skills (Composio)](https://github.com/ComposioHQ/awesome-claude-skills) | 49,300+ | 30 curated skills + 832 SaaS automation templates via Composio. Strong on document processing, creative, and business skills |
 | [awesome-claude-design](https://github.com/rohitg00/awesome-claude-design) | ![Stars](https://img.shields.io/github/stars/rohitg00/awesome-claude-design?style=flat-square&label=) | DESIGN.md files grouped by aesthetic family (editorial, terminal, warm, data-dense, cinematic, playful, glass, brutalist, indie) + remix recipes + prompt packs for Claude Design (Anthropic Labs) |
+| [Awesome AI Startups](https://github.com/nowork-studio/awesome-ai-startups) | new | Curated directory of ~440 indie-built AI products (bootstrapped, pre-seed, angel-funded) across 18 categories — AI agents, coding tools, marketing, audio/voice, image/design, video, and more |
 
 ## Contributing
 


### PR DESCRIPTION
Adds [Awesome AI Startups](https://github.com/nowork-studio/awesome-ai-startups) to the **Related Awesome Lists** table.

A curated directory of ~440 indie-built AI products from bootstrapped, pre-seed, and angel-funded startups, organized into 18 categories (AI agents, coding tools, marketing/SEO, audio/voice/music, video, image/design, writing, analytics, productivity, search, education, health, finance, APIs/SDKs, chatbots, social, e-commerce). Many entries are products built on Claude and other LLMs.

- Format matches the existing table schema (`| List | Stars | Focus |`)
- Used `new` for the Stars column (consistent with how AutoSearch is listed below the table) since this is a recently-published list
- Inserted at the bottom of the table, before the `## Contributing` heading
- Single-line addition; no other changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Awesome AI Startups" reference to the Related Awesome Lists section, providing access to a curated collection of approximately 440 indie AI products across 18 categories.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/awesome-claude-code-toolkit/pull/379)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->