### PR TITLE
Add cc-config-viewer to Companion Apps & GUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1010,6 +1010,7 @@ claude-code-toolkit/               850+ files
 | [cc-token-status](https://github.com/jayson-jia-dev/cc-token-status) | new | macOS menu bar dashboard for Claude Code. Shows live plan limits (5h/7d), costs, tokens, trends, model breakdown, user level system, and multi-machine iCloud sync. 5 languages, dark/light mode. Single Python file, auto-updates |
 | [Watchfire](https://github.com/watchfire-io/watchfire) | 33 | Orchestration platform for AI coding agents (starting with Claude Code). Manages project context, breaks work into tasks, runs agents with full codebase awareness. Git worktree isolation, sandboxed execution, multiple agent modes (chat, task, autonomous). Go daemon + CLI/TUI + Electron GUI |
 | [aby-claude-watcher](https://github.com/aby-agency/aby-claude-watcher) | new | Real-time macOS dashboard for Claude Code sessions. Five color-coded states (thinking, running, waiting, error, completed), per-session notifications, one-click focus terminal across iTerm2/Terminal/Warp/VSCode/Cursor/Ghostty/kitty/WezTerm/Hyper. Bilingual FR/EN, menu-bar tray, MIT licensed. Apple Silicon + Intel builds |
+| [cc-config-viewer](https://github.com/kuri-sun/cc-config-viewer) | new | Browser UI for Claude Code config. View and edit settings, rules, commands, agents, skills, and plugins across all four scopes (Managed / User / Project / Local), with a "Resolved" view of the merged effective settings. |
 
 ---
 


### PR DESCRIPTION
Adds [cc-config-viewer](https://github.com/kuri-sun/cc-config-viewer) to the **Companion Apps & GUIs** table.

It provides a browser UI for viewing and editing Claude Code config across all four scopes (Managed / User / Project / Local), with a "Resolved" view that shows the merged effective settings. Run it with `npx cc-config-viewer`. MIT licensed.

Appended at the bottom of the table to follow the chronological ordering of the existing entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated ecosystem documentation to include cc-config-viewer (a configuration management UI) and AutoSearch (an AI-driven research plugin).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/awesome-claude-code-toolkit/pull/383)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->