### PR TITLE
Add Eterna hybrid perp exchange MCP to Ecosystem + crypto-defi config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1158,6 +1158,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [Drevon](https://drevon.dev) | new | Mac desktop workspace for GTM engineers. Run parallel AI agents powered by Claude Code, Codex, or Copilot to build target lists, score accounts, and pull prospect intel. |
 | [voidly-mcp-server](https://github.com/voidly-ai/mcp-server) | new | 116 tools for Claude Code covering censorship intelligence (19.6M OONI measurements, 126 countries), E2E encrypted agent-to-agent messaging, and agent payments. Install: `claude mcp add voidly -- npx -y @voidly/mcp-server` |
 | [systemprompt-template](https://github.com/systempromptio/systemprompt-template) | -- | Governance infrastructure for Claude Code. Single compiled Rust binary that authenticates, authorises, rate-limits, logs, and attributes costs for every AI interaction before it reaches a tool or database. Self-hosted, air-gap capable, MCP + A2A compatible. BSL-1.1 |
+| [Eterna](https://github.com/EternaHybridExchange/eterna-ai) | new | Hybrid perp exchange MCP — deploy your own autonomous perp trading AI via Claude Code in 60 seconds. $10B+ aggregated liquidity across 500+ pairs, 24/7 live execution. Endpoint: `https://mcp.eterna.exchange/mcp` |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1158,7 +1158,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [Drevon](https://drevon.dev) | new | Mac desktop workspace for GTM engineers. Run parallel AI agents powered by Claude Code, Codex, or Copilot to build target lists, score accounts, and pull prospect intel. |
 | [voidly-mcp-server](https://github.com/voidly-ai/mcp-server) | new | 116 tools for Claude Code covering censorship intelligence (19.6M OONI measurements, 126 countries), E2E encrypted agent-to-agent messaging, and agent payments. Install: `claude mcp add voidly -- npx -y @voidly/mcp-server` |
 | [systemprompt-template](https://github.com/systempromptio/systemprompt-template) | -- | Governance infrastructure for Claude Code. Single compiled Rust binary that authenticates, authorises, rate-limits, logs, and attributes costs for every AI interaction before it reaches a tool or database. Self-hosted, air-gap capable, MCP + A2A compatible. BSL-1.1 |
-| [Eterna](https://github.com/EternaHybridExchange/eterna-ai) | new | Hybrid perp exchange MCP — deploy your own autonomous perp trading AI via Claude Code in 60 seconds. $10B+ aggregated liquidity across 500+ pairs, 24/7 live execution. Endpoint: `https://mcp.eterna.exchange/mcp` |
+| [Eterna AI](https://github.com/EternaHybridExchange/eterna-ai) | new | OAuth-based MCP + CLI for Eterna Exchange trading workflows. Agents can search SDK docs/examples and run managed TypeScript against the injected `eterna.*` SDK; trading actions should stay behind explicit user confirmation. Endpoint: `https://mcp.eterna.exchange/mcp` |
 
 ---
 

--- a/mcp-configs/crypto-defi.json
+++ b/mcp-configs/crypto-defi.json
@@ -21,9 +21,9 @@
       "description": "Track portfolio positions, price alerts, and research findings across sessions."
     },
     "eterna": {
-      "type": "sse",
+      "type": "streamable-http",
       "url": "https://mcp.eterna.exchange/mcp",
-      "description": "Eterna hybrid perp exchange — deploy an autonomous perp trading AI via Claude Code in 60 seconds. $10B+ aggregated liquidity across 500+ pairs, 24/7 execution."
+      "description": "OAuth-based MCP for Eterna Exchange trading workflows. Search SDK docs/examples and run managed TypeScript against the injected eterna.* SDK; keep trading actions behind explicit user confirmation."
     }
   }
 }

--- a/mcp-configs/crypto-defi.json
+++ b/mcp-configs/crypto-defi.json
@@ -19,6 +19,11 @@
       "command": "npx",
       "args": ["-y", "@modelcontextprotocol/server-memory"],
       "description": "Track portfolio positions, price alerts, and research findings across sessions."
+    },
+    "eterna": {
+      "type": "sse",
+      "url": "https://mcp.eterna.exchange/mcp",
+      "description": "Eterna hybrid perp exchange — deploy an autonomous perp trading AI via Claude Code in 60 seconds. $10B+ aggregated liquidity across 500+ pairs, 24/7 execution."
     }
   }
 }


### PR DESCRIPTION
## Changes

Two additions for Eterna's MCP server:

### 1. Ecosystem entry
Added to the Ecosystem table — Eterna is a hybrid perp exchange MCP that lets users deploy an autonomous perp trading AI via Claude Code in 60 seconds, with $10B+ aggregated liquidity across 500+ pairs.

### 2. crypto-defi.json config update
Added Eterna as an SSE MCP server to the Crypto/DeFi config — gives users live perp trading execution alongside the existing DeFi data tools.

- **Repo:** https://github.com/EternaHybridExchange/eterna-ai
- **MCP Endpoint:** https://mcp.eterna.exchange/mcp
- **Type:** SSE (hosted endpoint, no install needed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Eterna as a new MCP integration for exchange trading workflows (streamable HTTP, OAuth-backed).
  * Added CLI support and a TypeScript SDK surface for agent interactions; trading actions require explicit user confirmation.

* **Documentation**
  * Updated ecosystem docs to describe the Eterna integration, authentication, CLI and SDK usage, and MCP endpoint details.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/awesome-claude-code-toolkit/pull/390)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->