### PR TITLE
Add agent-lsp to Skills table

### DIFF
--- a/README.md
+++ b/README.md
@@ -541,7 +541,7 @@ Reference an agent in your `CLAUDE.md`:
 
 ## Skills
 
-Thirty-five curated skill modules included in this repo, with access to **400,000+ additional skills** via the [SkillKit marketplace](https://agenstskills.com). Each included skill teaches Claude Code domain-specific patterns with code examples, anti-patterns, and checklists.
+Thirty-six curated skill modules included in this repo, with access to **400,000+ additional skills** via the [SkillKit marketplace](https://agenstskills.com). Each included skill teaches Claude Code domain-specific patterns with code examples, anti-patterns, and checklists.
 
 | Skill | Directory | What It Teaches |
 |-------|-----------|-----------------|

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Claude Code Toolkit
 
-**The most comprehensive toolkit for Claude Code -- 135 agents, 35 curated skills (+400,000 via [SkillKit](https://agenstskills.com)), 42 commands, 176+ plugins, 20 hooks, 15 rules, 7 templates, 15 MCP configs, 26 companion apps, 53 ecosystem entries, and more.**
+**The most comprehensive toolkit for Claude Code -- 135 agents, 36 curated skills (+400,000 via [SkillKit](https://agenstskills.com)), 42 commands, 176+ plugins, 20 hooks, 15 rules, 7 templates, 15 MCP configs, 26 companion apps, 53 ecosystem entries, and more.**
 
 <p align="center">
   <a href="https://trendshift.io/repositories/21839" target="_blank"><img src="https://trendshift.io/api/badge/repositories/21839" alt="rohitg00%2Fawesome-claude-code-toolkit | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
@@ -48,7 +48,7 @@ curl -fsSL https://raw.githubusercontent.com/rohitg00/awesome-claude-code-toolki
 
 - [Plugins](#plugins) (176+)
 - [Agents](#agents) (135)
-- [Skills](#skills) (35 curated + 28 community)
+- [Skills](#skills) (36 curated + 28 community)
 - [Commands](#commands) (42)
 - [Hooks](#hooks) (20 scripts)
 - [Rules](#rules) (15)

--- a/README.md
+++ b/README.md
@@ -545,6 +545,7 @@ Thirty-five curated skill modules included in this repo, with access to **400,00
 
 | Skill | Directory | What It Teaches |
 |-------|-----------|-----------------|
+| agent-lsp | [`blackwell-systems/agent-lsp`](https://github.com/blackwell-systems/agent-lsp) | 24 LSP-backed code intelligence skills (refactor, rename, impact, verify, test-correlation, cross-repo, simulate) across 30 languages. Provides semantic understanding of code structure, references, type hierarchies, and call graphs. |
 | TDD Mastery | `skills/tdd-mastery/` | Red-green-refactor, test-first design, coverage targets |
 | API Design Patterns | `skills/api-design-patterns/` | RESTful conventions, versioning, pagination, error responses |
 | Database Optimization | `skills/database-optimization/` | Query planning, indexing, N+1 prevention, connection pooling |


### PR DESCRIPTION
## Summary

Adds [agent-lsp](https://github.com/blackwell-systems/agent-lsp) to the Skills table.

agent-lsp provides 24 LSP-backed code intelligence skills across 30 languages, teaching agents to work with code semantically rather than through text manipulation.

## What It Teaches

- **Code structure understanding**: type hierarchies, references, call graphs
- **Safe refactoring workflows**: blast-radius analysis, impact assessment, speculative editing
- **Cross-repository analysis**: find all usages of library symbols across consumer repos
- **Multi-language support**: Go, TypeScript, Python, Rust, Java, C++, PHP, Ruby, and 22 more

## Skills Included

- `/lsp-refactor` - end-to-end safe refactor with impact analysis
- `/lsp-rename` - workspace-wide symbol renames with validation
- `/lsp-impact` - blast-radius analysis before changes
- `/lsp-verify` - three-layer verification (diagnostics + build + tests)
- `/lsp-test-correlation` - find and run tests that cover a source file
- `/lsp-cross-repo` - cross-repository symbol analysis
- `/lsp-simulate` - speculative editing sessions before touching disk
- ...and 17 more

## Links

- Documentation: https://agent-lsp.com
- Install: `npm install -g @blackwell-systems/agent-lsp`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Skills count to 36 curated modules (tagline, table of contents, and Skills header).
  * Added a new Skills table entry for "agent-lsp" describing LSP-backed code intelligence across ~30 languages (refactor/rename/impact/verify/test-correlation/cross-repo/simulation).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/awesome-claude-code-toolkit/pull/393)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->