### PR TITLE
Add ctop — AI coding agent session monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1058,6 +1058,7 @@ claude-code-toolkit/               850+ files
 | [cctally](https://github.com/omrikais/cctally) | new | Track Claude Code subscription usage as a weekly $-per-1% trend. Local web dashboard, terminal UI, forecasts, threshold alerts. Apache-2.0, zero telemetry. |
 | [claude-code-notifier](https://github.com/saiso/claude-code-notifier) | new | Native macOS notifier for Claude Code. Swift + UserNotifications, custom Heroicons-derived icon (SF Symbols–free), click-through to your IDE (VS Code, Cursor, Windsurf, JetBrains, iTerm2, Terminal) via bundle ID swap, per-event sound labels, hardened inputs (allowlists, length caps, control-character stripping). Universal binary (arm64 + x86_64), macOS 12+, MIT |
 | [ToutKit](https://github.com/toutkit/toutkit) | new | Desktop notebook for AI CLIs (Claude Code, Codex, Gemini). Pairs a sidebar of notes with a built-in terminal and an in-app webview that renders whatever the AI writes — each note is a self-contained folder with its own SQLite, key/value store, attached files, and scripts, so a note can grow from a static page into a sortable table, dashboard, or research tool. Local-first, AGPL-3.0 |
+| [ctop](https://github.com/aakashadesara/ctop) | new | htop for AI coding agents. Monitor Claude Code and Codex CLI sessions with real-time CPU, memory, token usage, context window tracking, and cost estimates. Zero dependencies, pure Node.js |
 
 ---
 


### PR DESCRIPTION
## Summary

Adds [ctop](https://github.com/aakashadesara/ctop) to the **Companion Apps & GUIs** section.

ctop is htop for AI coding agents — monitor Claude Code and Codex CLI sessions with real-time CPU, memory, token usage, context window tracking, and cost estimates. Zero dependencies, pure Node.js.

- **Homepage**: https://aakashadesara.github.io/ctop/
- **Only README.md was modified** (one table row added to the Companion Apps & GUIs section)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added ctop to the Companion Apps & GUIs list—a monitoring tool for AI coding agents that tracks CPU, memory, token usage, context window, and cost estimates.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/awesome-claude-code-toolkit/pull/394)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->