### PR TITLE
Add claude46: pinned Claude Code launcher for Opus 4.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1162,6 +1162,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [voidly-mcp-server](https://github.com/voidly-ai/mcp-server) | new | 116 tools for Claude Code covering censorship intelligence (19.6M OONI measurements, 126 countries), E2E encrypted agent-to-agent messaging, and agent payments. Install: `claude mcp add voidly -- npx -y @voidly/mcp-server` |
 | [systemprompt-template](https://github.com/systempromptio/systemprompt-template) | -- | Governance infrastructure for Claude Code. Single compiled Rust binary that authenticates, authorises, rate-limits, logs, and attributes costs for every AI interaction before it reaches a tool or database. Self-hosted, air-gap capable, MCP + A2A compatible. BSL-1.1 |
 | [llm-prices](https://github.com/benbencodes/llm-prices) | new | CLI + Python library + MCP server to look up and compare LLM API costs across 167 models from 23 providers (OpenAI, Anthropic, Google, xAI, DeepSeek, Groq, and more). Ask Claude "what's the cheapest model for 10k input + 2k output?" before making API calls. Zero deps, no API key. `pipx install git+https://github.com/benbencodes/llm-prices` |
+| [claude46](https://github.com/sparklingneuronics/claude-code-helpers) | new | Pin Claude Code to Opus 4.6 + version 2.1.110 for reproducible workflows. Separate `claude46` launcher with auto-updates blocked, while normal `claude` keeps updating. macOS, Linux, WSL, Windows. MIT |
 
 ---
 


### PR DESCRIPTION
Adds claude46 to the Ecosystem section.

claude46 is a small open-source launcher that pins both the model (Opus 4.6) and the Claude Code version (2.1.110) in a separate command, while leaving the normal `claude` CLI free to auto-update.

- One-liner install for macOS, Linux, WSL, and native Windows
- Auto-updates blocked for the pinned launcher only
- MIT licensed, no telemetry

Repo: https://github.com/sparklingneuronics/claude-code-helpers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added ecosystem entry documentation describing version management and launcher configuration details.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/awesome-claude-code-toolkit/pull/398)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->