### PR TITLE
Add Septim Agents Pack — 10 named Claude Code sub-agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,7 @@ Or install all plugins at once:
 
 ## Agents
 
+- [Septim Agents Pack](https://septimlabs.com/agents) - 10 named Claude Code sub-agents (Atlas, Luca, Canon, Ember, Tally, Nova, Ward, Mira, Juno, Pip) covering the full solo-founder exec layer. Pip is open-sourced under MIT at github.com/septimlabs-code/septim-agents-pack-sample.
 One hundred thirty-five specialized agents organized into ten categories. Each agent defines a persona, system instructions, and tool access patterns.
 
 ### Core Development (13 agents)


### PR DESCRIPTION
Adds the [Septim Agents Pack](https://septimlabs.com/agents) — 10 named Claude Code sub-agents covering the full exec layer for solo founders (chief of staff, CTO, brand, CMO, CFO, design, legal, customer, research, intern coordinator).

The pack ships under the Claude Code sub-agent framework: each agent is a markdown file dropped into `~/.claude/agents/`, invoked via `/agents <name>`.

One agent (Pip the intern) is open-sourced under MIT at https://github.com/septimlabs-code/septim-agents-pack-sample so anyone can see the exact named-agent + scope + refusal-conditions format before buying the full pack.

Thanks for maintaining this list.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added information about Septim Agents Pack, introducing 10 Claude Code sub-agents with detailed descriptions and licensing information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/awesome-claude-code-toolkit/pull/401)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->