### PR TITLE
feat: add claudestat MCP server — real-time Claude Code monitor

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ curl -fsSL https://raw.githubusercontent.com/rohitg00/awesome-claude-code-toolki
 - [Hooks](#hooks) (20 scripts)
 - [Rules](#rules) (15)
 - [Templates](#templates) (7)
-- [MCP Configs](#mcp-configs) (14)
+- [MCP Configs](#mcp-configs) (17)
 - [Contexts](#contexts) (5)
 - [Examples](#examples) (3)
 - [Companion Apps & GUIs](#companion-apps--guis)
@@ -921,26 +921,27 @@ cp templates/claude-md/standard.md CLAUDE.md
 
 ## MCP Configs
 
-Sixteen curated Model Context Protocol server configurations.
+Seventeen curated Model Context Protocol server configurations.
 
 | Config | File | Servers Included |
 |--------|------|-----------------|
 | Recommended | [`recommended.json`](mcp-configs/recommended.json) | 14 essential servers for general development |
+| Claudestat | [`claudestat.json`](mcp-configs/claudestat.json) | Real-time Claude Code monitor — quota, session cost, top tools, usage insights |
+| Crypto / DeFi | [`crypto-defi.json`](mcp-configs/crypto-defi.json) | defi-mcp, Filesystem, Fetch, Memory |
+| Data Science | [`data-science.json`](mcp-configs/data-science.json) | Jupyter, SQLite, PostgreSQL, Filesystem |
+| Design | [`design.json`](mcp-configs/design.json) | Figma design context, Blender 3D automation |
+| DevOps | [`devops.json`](mcp-configs/devops.json) | AWS, Docker, GitHub, Terraform, Sentry |
+| E-Commerce | [`ecommerce.json`](mcp-configs/ecommerce.json) | BuyWhere product search, price comparison, deal discovery across 1M+ products |
+| Finance | [`finance.json`](mcp-configs/finance.json) | Helium news/markets/options, Chart Library pattern intelligence, Fetch, Memory |
+| Frontend | [`frontend.json`](mcp-configs/frontend.json) | Puppeteer, Figma, Storybook |
 | Full Stack | [`fullstack.json`](mcp-configs/fullstack.json) | Filesystem, GitHub, Postgres, Redis, Puppeteer |
 | Kubernetes | [`kubernetes.json`](mcp-configs/kubernetes.json) | kubectl-mcp-server, Docker, GitHub |
-| Data Science | [`data-science.json`](mcp-configs/data-science.json) | Jupyter, SQLite, PostgreSQL, Filesystem |
-| Frontend | [`frontend.json`](mcp-configs/frontend.json) | Puppeteer, Figma, Storybook |
-| Crypto / DeFi | [`crypto-defi.json`](mcp-configs/crypto-defi.json) | defi-mcp, Filesystem, Fetch, Memory |
-| DevOps | [`devops.json`](mcp-configs/devops.json) | AWS, Docker, GitHub, Terraform, Sentry |
-| Research | [`research.json`](mcp-configs/research.json) | BGPT scientific papers, Brave Search, Fetch, Memory, Filesystem |
-| Observability | [`observability.json`](mcp-configs/observability.json) | Iris eval & observability for agent tracing, quality evaluation, and cost tracking |
-| Security | [`security.json`](mcp-configs/security.json) | Ghidra reverse engineering, Snyk vulnerability scanning |
-| Design | [`design.json`](mcp-configs/design.json) | Figma design context, Blender 3D automation |
-| Workflow Automation | [`workflow-automation.json`](mcp-configs/workflow-automation.json) | n8n workflow builder, Pipedream integration |
-| Mobile | [`mobile.json`](mcp-configs/mobile.json) | Android ADB automation, Xcode build tools |
-| Finance | [`finance.json`](mcp-configs/finance.json) | Helium news/markets/options, Chart Library pattern intelligence, Fetch, Memory |
-| E-Commerce | [`ecommerce.json`](mcp-configs/ecommerce.json) | BuyWhere product search, price comparison, deal discovery across 1M+ products |
 | LLM Cost | [`llm-cost.json`](mcp-configs/llm-cost.json) | llm-prices: look up and compare API costs across 167 models from 23 providers before making calls |
+| Mobile | [`mobile.json`](mcp-configs/mobile.json) | Android ADB automation, Xcode build tools |
+| Observability | [`observability.json`](mcp-configs/observability.json) | Iris eval & observability for agent tracing, quality evaluation, and cost tracking |
+| Research | [`research.json`](mcp-configs/research.json) | BGPT scientific papers, Brave Search, Fetch, Memory, Filesystem |
+| Security | [`security.json`](mcp-configs/security.json) | Ghidra reverse engineering, Snyk vulnerability scanning |
+| Workflow Automation | [`workflow-automation.json`](mcp-configs/workflow-automation.json) | n8n workflow builder, Pipedream integration |
 
 ---
 
@@ -1003,7 +1004,7 @@ claude-code-toolkit/               850+ files
     scripts/                       19 Node.js scripts
   rules/                           15 coding rules
   templates/claude-md/             7 CLAUDE.md templates
-  mcp-configs/                     8 server configurations
+  mcp-configs/                     17 server configurations
   contexts/                        5 context modes
   examples/                        3 walkthrough examples
   setup/                           Interactive installer

--- a/mcp-configs/claudestat.json
+++ b/mcp-configs/claudestat.json
@@ -1,0 +1,18 @@
+{
+  "mcpServers": {
+    "claudestat": {
+      "command": "npx",
+      "args": ["-y", "@statforge/claudestat"],
+      "description": "Real-time Claude Code monitor. Query quota status, session cost, top tools, usage insights, model breakdown, and weekly statistics directly from inside Claude Code. No setup required — starts instantly.",
+      "tools": [
+        "get_quota_status",
+        "get_current_session",
+        "get_session_stats",
+        "get_top_tools",
+        "get_usage_insights",
+        "get_model_breakdown",
+        "get_weekly_insight"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Adds claudestat to the MCP configs section. claudestat exposes 7 MCP tools that let Claude Code query its own usage stats (quota, session cost, top tools, model breakdown) in real time from inside a session.

## Changes
- **mcp-configs/claudestat.json**: New MCP server config for @statforge/claudestat
- **README.md**: Updated MCP Configs table (alphabetically ordered) and count from 16→17

## Package Info
- npm: `@statforge/claudestat`
- GitHub: https://github.com/DeibyGS/claudestat
- Tools: get_quota_status, get_current_session, get_session_stats, get_top_tools, get_usage_insights, get_model_breakdown, get_weekly_insight

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Claudestat MCP server configuration enabling access to quota status, session tracking, usage analytics, and performance insights.

* **Documentation**
  * Updated README to reflect expanded MCP server configurations, now totaling 17 available servers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/awesome-claude-code-toolkit/pull/419?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->