### PR TITLE
Add harness-maker to Ecosystem section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1215,6 +1215,7 @@ Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines
 
 [Apache-2.0](LICENSE)
 | [AutoSearch](https://github.com/0xmariowu/Autosearch) | new | Self-evolving deep research plugin for Claude Code -- 32 dedicated search channels (arXiv, GitHub, Reddit, HN, zhihu, bilibili, CSDN + 25 more), LLM-scored evaluation, cited reports in Markdown/HTML/Slides, cross-session learning. Zero API keys required |
+| [harness-maker](https://github.com/Ecro/harness-maker) | new | Project-tailored AI coding harness generator for Claude Code · Cursor · Codex. 12+ stack profiler + 10-dim interview, grade-gated review with auto-fix loop, edit-preserving block-merge upgrades (\), weekly anti-rot crawl (Anthropic / GitHub / arXiv / OSV), worktree-isolated execute, privilege-separated reviewers (read-only), 100% local telemetry. \ or \Adding marketplace…. MIT |
 
 
 ---


### PR DESCRIPTION
Adds [`harness-maker`](https://github.com/Ecro/harness-maker) as one row in the Ecosystem table.

## What it is

Project-tailored AI coding harness generator for **Claude Code · Cursor · Codex**. Single source (`harness.yaml`), three IDE-native renders.

| Pillar | What it does |
|---|---|
| **Project-tailored synthesis** | Profiler reads 12+ stack/framework/CI signals before any prompt; 10-dimension interview locks the rest. A `Side` experiment and a `Production` service get structurally different harnesses — different reviewer counts, workflow stages, security gates. |
| **Edit-preserving upgrades** | Hand-edit any agent / skill / CLAUDE.md. Block-merge markers (\`@hm:user:*\`) carry your edits across \`--update\`. |
| **Anti-rot crawl** | Weekly fetch across Anthropic blog · GitHub releases · arXiv · OSV CVEs. Adaptive relevance filter learns from accept/reject history. Manual confirmation only — no silent auto-apply. |
| **Privilege-separated reviewers** | Reviewer agents (\`code\`, \`security\`, \`performance\`, \`concurrency\`, \`UX\`) are read-only by permission; stage orchestrator applies fixes. Mechanical checks (lint/tests) gate the LLM reviewer before any token is spent. |
| **Local-only telemetry** | All telemetry stays on disk under \`.claude/observability/\`. Schema documented in [PRIVACY.md](https://github.com/Ecro/harness-maker/blob/main/PRIVACY.md); an AST-walk unit test fails any PR that adds a field without doc update. |

## Install

\`\`\`bash
# Any IDE — CLI
pip install harness-maker

# Or as a Claude Code plugin
/plugin marketplace add Ecro/harness-maker
/plugin install harness-maker@harness-maker
\`\`\`

## Status

- License: **MIT**
- Version: 0.x (breaking-policy documented in README §Stability — frozen surfaces named: slash command names, \`harness.yaml\` top-level keys, plugin manifest schemas)
- Solo-maintained, "PRs at your own risk" (CONTRIBUTING.md is honest about SLA)
- PyPI since 0.15.3, current 0.17.0

## Files changed

- `README.md`: one row appended to the Ecosystem table.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "harness-maker" project entry to the README, documenting a new AI-assisted coding tool available under MIT license.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/awesome-claude-code-toolkit/pull/422?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->