### PR TITLE
Add: retro-daily — SessionStart hook for daily Claude Code retros

### DIFF
--- a/README.md
+++ b/README.md
@@ -817,6 +817,7 @@ Twenty hook scripts covering all eight Claude Code lifecycle events. Place `hook
 | `learning-log.js` | SessionEnd | Extract and save session learnings |
 | `pre-compact.js` | PreCompact | Save important context before compaction |
 | [`smart-approve.py`](https://github.com/liberzon/claude-hooks) | PreToolUse (Bash) | Decompose compound bash commands (&&, \|\|, ;, \|, $()) into sub-commands and check each against allow/deny patterns |
+| [`retro-daily`](https://github.com/gyanesh-m/retro-daily) | SessionStart | Prints a daily retro at the top of every session — competency grade (0–100, A–F), 14-day efficiency sparklines, year-long contributions heatmap. Spawns a detached, sandboxed `claude -p` worker that researches your weakest metrics on docs.anthropic.com and GitHub and surfaces findings inline next session. [Demo](https://gyanesh-m.github.io/retro-daily/) · MIT |
 | `block-dev-server.js` | PreToolUse (Bash) | Block dev server commands outside tmux |
 | `pre-push-check.js` | PreToolUse (Bash) | Verify branch and remote before push |
 | `block-md-creation.js` | PreToolUse (Write) | Block unnecessary .md file creation |

--- a/README.md
+++ b/README.md
@@ -817,7 +817,7 @@ Twenty hook scripts covering all eight Claude Code lifecycle events. Place `hook
 | `learning-log.js` | SessionEnd | Extract and save session learnings |
 | `pre-compact.js` | PreCompact | Save important context before compaction |
 | [`smart-approve.py`](https://github.com/liberzon/claude-hooks) | PreToolUse (Bash) | Decompose compound bash commands (&&, \|\|, ;, \|, $()) into sub-commands and check each against allow/deny patterns |
-| [`retro-daily`](https://github.com/gyanesh-m/retro-daily) | SessionStart | Prints a daily retro at the top of every session — competency grade (0–100, A–F), 14-day efficiency sparklines, year-long contributions heatmap. Spawns a detached, sandboxed `claude -p` worker that researches your weakest metrics on docs.anthropic.com and GitHub and surfaces findings inline next session. [Demo](https://gyanesh-m.github.io/retro-daily/) · MIT |
+| [`retro-daily`](https://github.com/gyanesh-m/retro-daily) | SessionStart | Prints a daily retro at the top of every session — competency grade (0–100, A–F), 14-day efficiency sparklines, year-long contributions heatmap. Also starts a detached, sandboxed `claude -p` background worker (network access to docs.anthropic.com/GitHub) to research weakest metrics and surface findings next session; opt out with `RETRO_DAILY_NO_BACKGROUND_WORKERS=1`, rate-limit via `SCOUT_STALE_DAYS` (default 7). [Demo](https://gyanesh-m.github.io/retro-daily/) · MIT |
 | `block-dev-server.js` | PreToolUse (Bash) | Block dev server commands outside tmux |
 | `pre-push-check.js` | PreToolUse (Bash) | Verify branch and remote before push |
 | `block-md-creation.js` | PreToolUse (Write) | Block unnecessary .md file creation |


### PR DESCRIPTION
## What this adds

**[retro-daily](https://github.com/gyanesh-m/retro-daily)** — a `SessionStart` hook that prints a daily retro at the top of every Claude Code session: competency grade (0–100 / A–F), 14-day efficiency sparklines, year-long contributions heatmap, and a detached `claude -p` background worker that researches your weakest metrics on docs.anthropic.com and GitHub and surfaces findings inline next session.

Installs as a single-plugin marketplace:

```
/plugin marketplace add gyanesh-m/retro-daily
/plugin install retro-daily@retro-daily
/reload-plugins
```

- Repo: https://github.com/gyanesh-m/retro-daily
- Demo: https://gyanesh-m.github.io/retro-daily/
- License: MIT

## Where it goes

Added one row to the **Hooks → Hook Scripts** table, right under `smart-approve.py` (the other external-link hook entry), keeping the external-repo entries grouped at the top.

## Why it fits

It's a hook first and a dashboard second — the `SessionStart` hook is the entry point and everything else (metrics dashboard, background scout worker) flows from there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added docs for a new "retro-daily" hook that shows a daily metrics review (grade, efficiency sparklines, contributions heatmap), can launch an optional sandboxed background research worker for weak metrics with configurable limits and opt-out, and includes a demo link and license information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/awesome-claude-code-toolkit/pull/427?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->