### PR TITLE
Add Ano to Companion Apps & GUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1060,6 +1060,7 @@ claude-code-toolkit/               850+ files
 | [ToutKit](https://github.com/toutkit/toutkit) | new | Desktop notebook for AI CLIs (Claude Code, Codex, Gemini). Pairs a sidebar of notes with a built-in terminal and an in-app webview that renders whatever the AI writes — each note is a self-contained folder with its own SQLite, key/value store, attached files, and scripts, so a note can grow from a static page into a sortable table, dashboard, or research tool. Local-first, AGPL-3.0 |
 
 ---
+| [Ano](https://ano.chat/) | - | High-performance collaborative chat and workspace for devs that combines real-time messaging with a native in-app terminal and integrated AI (like Claude Code) |
 
 ## Ecosystem
 


### PR DESCRIPTION
Added [Ano](https://ano.chat/) to the Companion Apps & GUIs table. Ano integrates Claude Code, custom skills, and terminal sessions natively inside a collaborative developer chat.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Ano to the companion apps & GUIs reference guide, featuring collaborative chat and integrated terminal capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/awesome-claude-code-toolkit/pull/431?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->