### PR TITLE
Add new-plugin: dot-me

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ Over 176 production-ready plugins that extend Claude Code with domain-specific c
 | [desktop-app](plugins/desktop-app/) | Desktop application scaffolding with Electron or Tauri |
 | [devops-automator](plugins/devops-automator/) | DevOps automation scripts for CI/CD, health checks, and deployments |
 | [discuss](plugins/discuss/) | Debate implementation approaches with structured pros and cons analysis |
+| [dot-me](https://github.com/thebestmensch/dot-me) | Loads `~/.me/identity.yaml` into session context at SessionStart and ships `/me` for managing four user-context files (identity, voice, preferences, working-style). Reference Claude Code consumer of the dot-me v0.3 spec; sibling consumers ship for Codex CLI, Cursor, and Gemini CLI. |
 | [claw-army/claude-node](https://github.com/claw-army/claude-node) | Python subprocess bridge for Claude Code CLI, giving Python code direct access to Claude Code native capabilities via stream-json |
 | [discoclaw](https://github.com/DiscoClaw/discoclaw) | Personal AI orchestrator that bridges Discord to Claude Code with durable memory, task tracking, and cron-based automation |
 | [jarvis](https://github.com/Ramsbaby/jarvis) | Turns an idle Claude Max subscription into a 24/7 AI ops system — Discord bot, 76 scheduled tasks, 12 AI teams, local LanceDB RAG, 98% context compression via Nexus CIG, and 4-layer self-healing infrastructure. Uses `claude -p` headless mode at $0 extra cost. |


### PR DESCRIPTION
## What this adds

- One row in the All Plugins table linking to https://github.com/thebestmensch/dot-me

## About the plugin

dot-me loads `~/.me/identity.yaml` into session context at SessionStart and ships the `/me` slash command for managing four user-context files (identity, voice, preferences, working-style). The folder is the portable spec; this entry points at the Claude Code reference consumer. Spec is at https://github.com/thebestmensch/dot-me, currently v0.3 RFC stage. Reference consumers also ship for Codex CLI, Cursor, and Gemini CLI.

Tested on Claude Code 2.1.x. MIT.

Placed in the All Plugins table (alphabetical) as an external-link entry, matching the existing pattern for plugins maintained outside this repo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the `dot-me` plugin to the Plugins list, including details about its functionality and capabilities.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/awesome-claude-code-toolkit/pull/439?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->