### PR TITLE
Add voight-sdk to Hooks → Related SDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -838,6 +838,7 @@ If you prefer a typed, npm-installable foundation for writing hooks rather than 
 
 - [claude-code-hooks](https://github.com/Payshak/claude-code-hooks) — TypeScript SDK with `defineHook()`, typed event payloads for all 5 hook events, response builders, and unit-testable `.handle()` method. Zero dependencies.
 - [EchoCoding](https://github.com/launsion-boop/EchoCoding) — Audio layer for coding agents with hook-triggered SFX, ambient soundscape, and optional cloud TTS/ASR voice interaction. Works with Claude Code hooks and also supports Cursor/Windsurf, Codex CLI, and Gemini CLI.
+- [voight-sdk](https://github.com/Voightxyz/voight-sdk) — Real-time observability SDK that hooks Claude Code's lifecycle events to capture prompts, tool calls, tokens, cost, latency, and errors into a hosted dashboard. Also supports Cursor via the same hook adapter.
 
 ### Installing Hooks
 


### PR DESCRIPTION
Adds voight-sdk to the Hooks → Related SDKs subsection.

Real-time observability SDK that uses Claude Code's hook lifecycle (PreToolUse / PostToolUse / Stop / UserPromptSubmit / PreCompact) to capture every prompt, tool call, token cost, cache read, latency, and error into a hosted dashboard. Three privacy levels with local PII scrubbing.

- Repo: https://github.com/Voightxyz/voight-sdk
- npm: @voightxyz/sdk
- License: Apache 2.0
- Also covers Cursor (same hook adapter) and Vercel AI SDK (via @voightxyz/vercel-ai OTel exporter)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added voight-sdk to the Related SDKs section, highlighting its real-time observability capabilities for capturing lifecycle events and supporting multiple environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/awesome-claude-code-toolkit/pull/440?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->