### PR TITLE
Add cue — agent profile manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ Over 176 production-ready plugins that extend Claude Code with domain-specific c
 | [cron-scheduler](plugins/cron-scheduler/) | Cron job configuration and schedule validation |
 | [css-cleaner](plugins/css-cleaner/) | Find unused CSS and consolidate stylesheets |
 | [cup](https://github.com/krodak/clickup-cli) | ClickUp CLI for AI agents with task management, sprints, and time tracking |
+| [cue](https://github.com/recodeee/cue) ([npm](https://www.npmjs.com/package/cue-ai)) | Agent profile manager — per-directory skill/MCP/plugin isolation with inheritance, content-addressed caching (<5ms), TUI picker, 19 profiles, 110+ skills. Supports 10 agents (Claude Code, Codex, Cursor, Cline, Gemini, Copilot, Windsurf, Roo, Amp, Aider). `npm i -g cue-ai` |
 | [data-privacy](plugins/data-privacy/) | Data privacy implementation with PII detection and anonymization |
 | [database-optimizer](plugins/database-optimizer/) | Database query optimization with index recommendations and EXPLAIN analysis |
 | [dead-code-finder](plugins/dead-code-finder/) | Find and remove dead code across the codebase |


### PR DESCRIPTION
**cue** is an agent profile manager that scopes skills, MCPs, and plugins per-directory for Claude Code & Codex (and 8 more agents).

- GitHub: https://github.com/recodeee/cue
- npm: https://www.npmjs.com/package/cue-ai  
- MIT licensed
- Per-directory `.cue-profile` pinning
- YAML profiles with inheritance
- Content-addressed caching (<5ms overhead)
- Works with 10 agents
- 19 profiles, 110+ skills ship out of the box

Install: `npm install -g cue-ai`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the plugin list to include the `cue` plugin with its npm package link and description.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/awesome-claude-code-toolkit/pull/442?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->