### PR TITLE
Add ux plugin: design intelligence for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,6 +273,7 @@ Over 176 production-ready plugins that extend Claude Code with domain-specific c
 | [tool-evaluator](plugins/tool-evaluator/) | Evaluate and compare developer tools with structured scoring criteria |
 | [type-migrator](plugins/type-migrator/) | Migrate JavaScript files to TypeScript with proper types |
 | [ui-designer](plugins/ui-designer/) | Implement UI designs from specs with pixel-perfect component generation |
+| [ux](https://github.com/Laith0003/ux-skill) | Design intelligence for Claude Code: 18 slash commands, 5 sub-agents, deterministic regex linter (no LLM), 72 brand DESIGN.md specs (Apple, Stripe, Linear, Figma, Tesla). Anti-AI-slop. MIT. |
 | [ultrathink](plugins/ultrathink/) | Deep analysis mode with extended reasoning for complex problems |
 | [unit-test-generator](plugins/unit-test-generator/) | Generate comprehensive unit tests for any function or module |
 | [update-branch](plugins/update-branch/) | Rebase and update feature branches with conflict resolution |

--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ Over 176 production-ready plugins that extend Claude Code with domain-specific c
 | [tool-evaluator](plugins/tool-evaluator/) | Evaluate and compare developer tools with structured scoring criteria |
 | [type-migrator](plugins/type-migrator/) | Migrate JavaScript files to TypeScript with proper types |
 | [ui-designer](plugins/ui-designer/) | Implement UI designs from specs with pixel-perfect component generation |
-| [ux](https://github.com/Laith0003/ux-skill) | Design intelligence for Claude Code: 18 slash commands, 5 sub-agents, deterministic regex linter (no LLM), 72 brand DESIGN.md specs (Apple, Stripe, Linear, Figma, Tesla). Anti-AI-slop. MIT. |
+| [ux](https://github.com/Laith0003/ux-skill) | Design intelligence for Claude Code: 25 slash commands, 5 sub-agents, deterministic 152-rule anti-slop linter (no LLM), 160 brand specs (Apple, Stripe, Linear, Figma, Tesla and more). Anti-AI-slop. MIT. |
 | [ultrathink](plugins/ultrathink/) | Deep analysis mode with extended reasoning for complex problems |
 | [unit-test-generator](plugins/unit-test-generator/) | Generate comprehensive unit tests for any function or module |
 | [update-branch](plugins/update-branch/) | Rebase and update feature branches with conflict resolution |


### PR DESCRIPTION
## What's being added

**Plugin name:** `ux`
**Repository:** https://github.com/Laith0003/ux-skill
**Live landing:** https://uxskill.laithjunaidy.com
**License:** MIT
**Section:** Plugins → All Plugins (alphabetical, between `ui-designer` and `ultrathink`)

## Description

A comprehensive UX intelligence layer for Claude Code that produces frontend work that doesn't read as AI-generated.

- 18 callable slash commands across Frame / Audit / Generate / Apply
- 5 specialized sub-agents (frontend-engineer, motion-engineer, copy-writer, research-synthesizer, design-system-architect)
- 30+ Polaris-style reference files
- Deterministic regex linter (`/ux-lint`) — no LLM, CI-friendly, 30 anti-pattern rules
- 72 brand DESIGN.md specs — Apple, Stripe, Linear, Notion, Figma, Tesla, BMW, Ferrari, Coinbase, Airbnb, Shopify and 61 more
- Mandatory 10-field discovery protocol before any generation
- SEO foundation baked into every public-web output
- Cross-stack: React, Next.js, Vue, Blade + Alpine, Astro, vanilla HTML

## Install

```
/plugin marketplace add https://github.com/Laith0003/ux-skill.git
/plugin install ux@ux-skill
```

Also submitted to the official Anthropic marketplace ([PR #2010](https://github.com/anthropics/claude-plugins-official/pull/2010)) — once merged, plain `/plugin install ux` will work without the marketplace add step.

## Test plan

1. Visit the live landing at https://uxskill.laithjunaidy.com for design proof
2. `gh repo clone Laith0003/ux-skill` to inspect the manifest, commands, sub-agents
3. The plugin is MIT-licensed, no telemetry, no API keys required, no network calls in the linter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added the "ux" plugin to the Plugins catalog with a one-line description and attribution/license text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->