### PR TITLE
Add Selvedge to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1162,6 +1162,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [voidly-mcp-server](https://github.com/voidly-ai/mcp-server) | new | 116 tools for Claude Code covering censorship intelligence (19.6M OONI measurements, 126 countries), E2E encrypted agent-to-agent messaging, and agent payments. Install: `claude mcp add voidly -- npx -y @voidly/mcp-server` |
 | [systemprompt-template](https://github.com/systempromptio/systemprompt-template) | -- | Governance infrastructure for Claude Code. Single compiled Rust binary that authenticates, authorises, rate-limits, logs, and attributes costs for every AI interaction before it reaches a tool or database. Self-hosted, air-gap capable, MCP + A2A compatible. BSL-1.1 |
 | [llm-prices](https://github.com/benbencodes/llm-prices) | new | CLI + Python library + MCP server to look up and compare LLM API costs across 167 models from 23 providers (OpenAI, Anthropic, Google, xAI, DeepSeek, Groq, and more). Ask Claude "what's the cheapest model for 10k input + 2k output?" before making API calls. Zero deps, no API key. `pipx install git+https://github.com/benbencodes/llm-prices` |
+| [Selvedge](https://github.com/masondelan/selvedge) | new | Local MCP server that captures the *why* behind every change Claude Code makes — and with `prior_attempts` (v0.3.7) the agent reads prior reasoning before it edits. Seven tools (`log_change`, `diff`, `blame`, `history`, `changeset`, `search`, `prior_attempts`). Local SQLite, MIT, `pip install selvedge`. |
 
 ---
 


### PR DESCRIPTION
Adding Selvedge to the Ecosystem table.

**What it is:** A local MCP server purpose-built for the "AI-coded codebase" problem — when a meaningful chunk of your code was written by Claude Code, `git blame` points at a model, generated commit messages have lost the prompt context, and the original session is gone. Selvedge captures the agent's reasoning *live*, in context, before the session ends.

**Why it fits this toolkit:** Selvedge is one of a small number of MCP servers built specifically for Claude Code workflows. `selvedge setup` detects Claude Code, drops the canonical agent-instructions block into your `CLAUDE.md`, writes the MCP entry into your config, and installs the post-commit hook — one command, ~90 seconds.

**Stats**
- v0.3.7 latest, pytest/ruff/mypy all green
- Python 3.10–3.13 × SQLite 3.37–3.45 matrix (pinned via LD_PRELOAD)
- MIT, zero telemetry, all data local
- Companion listings: [Glama](https://glama.ai/mcp/servers/masondelan/selvedge), [Smithery](https://smithery.ai/server/masondelan/selvedge), [PyPI](https://pypi.org/project/selvedge/), [mcpservers.org](https://mcpservers.org/servers/masondelan/selvedge), [selvedge.sh](https://selvedge.sh)

**Tools exposed (seven):** `log_change`, `diff`, `blame`, `history`, `changeset`, `search`, `prior_attempts` — with `prior_attempts`, the agent reads prior reasoning before it edits.

Happy to revise placement, formatting, or wording per the toolkit's conventions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Selvedge to the Ecosystem—a local MCP server that logs Claude Code edit details, offering tools for change tracking, diffs, blame history, and changesets with local SQLite storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->