### PR TITLE
Add solo-ttrpg-vault-template to templates/project-starters

### DIFF
--- a/solo-ttrpg-vault-template.md
+++ b/solo-ttrpg-vault-template.md
@@ -2,7 +2,7 @@
 
   A system- and setting-agnostic vault template for running solo tabletop RPGs with Claude Code as the GM.
 
-  ## What it does
+## What it does
 
   A scaffolding kit for multi-month solo TTRPG campaigns where the LLM is the GM and the human is the player. Distilled from two real solo campaigns (Imperium Maledictum d100 and Cyberpunk RED d10). System- and setting-agnostic — you bring the system, PC, and setting; the
   template provides the structural conventions that make multi-month campaigns work.
@@ -16,7 +16,7 @@
   - **NPC scaffolds** — per-PC custom-tracker pattern, motivation-first NPC formula (want + distinctive marker + relationship memory + optional secret for antagonists), functionary templates
   - **MIGRATION.md** for forking older versions
 
-  ## Quick start
+## Quick start
 
   1. Click **Use this template** at https://github.com/Mirsellus/solo-ttrpg-vault-template or clone the repo
   2. Open Claude Code in the cloned directory; ask: *"I just cloned this, what is it and where do I start?"*
@@ -24,12 +24,12 @@
   4. Walk Stages 2–7 (rulebooks → tone → character creation → slash commands → world bible → permissions)
   5. Run the Stage 8 readiness gates before session 1
 
-  ## Links
+## Links
 
   - **Repository**: https://github.com/Mirsellus/solo-ttrpg-vault-template
   - **License**: MIT
 
-  ## Why use this
+## Why use this
 
   Fills the empty quadrant in public Claude Code TTRPG tooling. Most existing public projects are d20-locked (built-in 5e rules), solo-without-GM (oracle-driven, no LLM-GM structure), or RAG-dependent. This one is system-agnostic, GM-with-human-player, and ships scaffolds rather
   than rules.

--- a/solo-ttrpg-vault-template.md
+++ b/solo-ttrpg-vault-template.md
@@ -1,0 +1,38 @@
+# Solo TTRPG Vault Template
+
+  A system- and setting-agnostic vault template for running solo tabletop RPGs with Claude Code as the GM.
+
+  ## What it does
+
+  A scaffolding kit for multi-month solo TTRPG campaigns where the LLM is the GM and the human is the player. Distilled from two real solo campaigns (Imperium Maledictum d100 and Cyberpunk RED d10). System- and setting-agnostic — you bring the system, PC, and setting; the
+  template provides the structural conventions that make multi-month campaigns work.
+
+  - **Slash commands**: `/play` (eager-load play context — character sheet, live state, rules quick-ref, tone docs, GM notes), `/roll` (Python-based dice with full Roll20 notation: Fudge, exploding, success-counting, keep-highest), `/oracle` (multi-system content randomness:
+  axis, fate yes/no, tarot, runes, I Ching, prompt pairs)
+  - **Six-file setup playbook** covering ~6–10 hours of campaign bringup (Setup Phases, Question Bank, Technical Patterns, Pitfalls and Lessons, Recurring Patterns)
+  - **Scene Pacing Framework** — chunk taxonomy, ambient erosion, escalation ladder, per-chunk event checks; picks one of two resolution-engine patterns to match the system
+  - **Tone framework** — Themes (content scope), Voice (prose register)
+  - **GM Craft companion** — failure-handling spectrum (succeed-at-cost / fail-forward / hard fail), narrative authority handoff on critical successes, improv response spectrum (Yes-and / Yes-but / No-but / "you can certainly try")
+  - **NPC scaffolds** — per-PC custom-tracker pattern, motivation-first NPC formula (want + distinctive marker + relationship memory + optional secret for antagonists), functionary templates
+  - **MIGRATION.md** for forking older versions
+
+  ## Quick start
+
+  1. Click **Use this template** at https://github.com/Mirsellus/solo-ttrpg-vault-template or clone the repo
+  2. Open Claude Code in the cloned directory; ask: *"I just cloned this, what is it and where do I start?"*
+  3. Walk Stage 1 of `_README.md`: copy to a campaign directory, fix `.gitignore`, fill `CLAUDE.md` + `Setup Notes.md` with system / character / setting
+  4. Walk Stages 2–7 (rulebooks → tone → character creation → slash commands → world bible → permissions)
+  5. Run the Stage 8 readiness gates before session 1
+
+  ## Links
+
+  - **Repository**: https://github.com/Mirsellus/solo-ttrpg-vault-template
+  - **License**: MIT
+
+  ## Why use this
+
+  Fills the empty quadrant in public Claude Code TTRPG tooling. Most existing public projects are d20-locked (built-in 5e rules), solo-without-GM (oracle-driven, no LLM-GM structure), or RAG-dependent. This one is system-agnostic, GM-with-human-player, and ships scaffolds rather
+  than rules.
+
+  Attribution: `scripts/oracle.py` and `scripts/dice.py` are MIT-licensed verbatim ports from [serelon/rpg-tools](https://github.com/serelon/rpg-tools) (headers and LICENSE preserved at `scripts/LICENSE-rpg-tools.txt`). `World Bible/GM Craft.md` paraphrases structure from
+  [rjroy/adventure-engine-corvran](https://github.com/rjroy/adventure-engine-corvran)'s gm-craft skill (also MIT) — paraphrased rather than verbatim, with explicit attribution in the file's §5.


### PR DESCRIPTION
Adds a project-starter for solo TTRPG campaigns with Claude Code as the GM.

## What this adds

  A new markdown file at `templates/project-starters/solo-ttrpg-vault-template.md` describing the [solo-ttrpg-vault-template](https://github.com/Mirsellus/solo-ttrpg-vault-template) repository — a system- and setting-agnostic vault scaffold for the LLM-as-GM solo TTRPG case.

## Why

  The toolkit's existing project-starters section is small, and TTRPG content sits in an empty quadrant: existing public Claude Code TTRPG tooling is either d20-locked (with built-in 5e rules), solo-without-GM (oracle-driven, no LLM-GM structure), or RAG-dependent. This template fills the actual middle: system-agnostic, GM-with-human-player solo play, with structural patterns distilled from two real multi-month campaigns. Useful project-starter for anyone scaffolding their own LLM-as-GM solo campaign.

## Conventions followed

  - Matches the format of `templates/project-starters/phoenix-prime-starter.md` (title, what-it-does, quick-start, links, why-use-this)
  - File named `solo-ttrpg-vault-template.md` per the kebab-case convention in CONTRIBUTING.md
  - MIT-licensed; attribution preserved for upstream MIT-licensed code ports (`serelon/rpg-tools`, `rjroy/adventure-engine-corvran`)
  - No generated-attribution footers in the file

## Note on the README

  CONTRIBUTING.md mentions "Update the README table if adding a new item to any category." Happy to update the README's Templates section in a follow-up commit if the maintainer prefers — I held off in this PR since the project-starters subsection is small and I wasn't sure of the preferred ordering / formatting for that table. Just let me know.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a system‑agnostic solo TTRPG vault template for Claude Code, including slash commands, a six‑part (~6–10 hr) campaign bring‑up playbook, scene pacing and resolution frameworks, a tone framework, NPC scaffolds, and a quick‑start workflow.
  * Added a “GM Craft” companion covering failure handling and improv response guidance.

* **Documentation**
  * Added template docs with setup/quick‑start guidance, migration notes, repository/license links, and attribution information.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/awesome-claude-code-toolkit/pull/467?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->