### PR TITLE
Add Helix to Companion Apps & GUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1058,6 +1058,7 @@ claude-code-toolkit/               850+ files
 | [cctally](https://github.com/omrikais/cctally) | new | Track Claude Code subscription usage as a weekly $-per-1% trend. Local web dashboard, terminal UI, forecasts, threshold alerts. Apache-2.0, zero telemetry. |
 | [claude-code-notifier](https://github.com/saiso/claude-code-notifier) | new | Native macOS notifier for Claude Code. Swift + UserNotifications, custom Heroicons-derived icon (SF Symbols–free), click-through to your IDE (VS Code, Cursor, Windsurf, JetBrains, iTerm2, Terminal) via bundle ID swap, per-event sound labels, hardened inputs (allowlists, length caps, control-character stripping). Universal binary (arm64 + x86_64), macOS 12+, MIT |
 | [ToutKit](https://github.com/toutkit/toutkit) | new | Desktop notebook for AI CLIs (Claude Code, Codex, Gemini). Pairs a sidebar of notes with a built-in terminal and an in-app webview that renders whatever the AI writes — each note is a self-contained folder with its own SQLite, key/value store, attached files, and scripts, so a note can grow from a static page into a sortable table, dashboard, or research tool. Local-first, AGPL-3.0 |
+| [Helix](https://github.com/tomarai85/helix-releases) | new | Native macOS terminal for running multiple Claude Code agents side by side — several panes plus a preview canvas in one view, so you can watch several sub-agents at once. The step up from tmux for agentic coding |
 
 ---
 


### PR DESCRIPTION
Adds Helix to the **Companion Apps & GUIs** section.

Helix is a native macOS terminal for running multiple Claude Code agents side by side — several panes plus a preview canvas in one view, so you can watch several sub-agents at once. macOS, free beta.

Repo: https://github.com/tomarai85/helix-releases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Helix to the companion apps and GUIs section—a native macOS terminal for running multiple Claude Code agents side-by-side with panes and a preview canvas.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/rohitg00/awesome-claude-code-toolkit/pull/472?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->