### PR TITLE
feat: add claudestat MCP config

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ curl -fsSL https://raw.githubusercontent.com/rohitg00/awesome-claude-code-toolki
 - [Hooks](#hooks) (20 scripts)
 - [Rules](#rules) (15)
 - [Templates](#templates) (7)
-- [MCP Configs](#mcp-configs) (14)
+- [MCP Configs](#mcp-configs) (17)
 - [Contexts](#contexts) (5)
 - [Examples](#examples) (3)
 - [Companion Apps & GUIs](#companion-apps--guis)
@@ -921,26 +921,27 @@ cp templates/claude-md/standard.md CLAUDE.md
 
 ## MCP Configs
 
-Sixteen curated Model Context Protocol server configurations.
+Seventeen curated Model Context Protocol server configurations.
 
 | Config | File | Servers Included |
 |--------|------|-----------------|
 | Recommended | [`recommended.json`](mcp-configs/recommended.json) | 14 essential servers for general development |
+| Claudestat | [`claudestat.json`](mcp-configs/claudestat.json) | Real-time Claude Code monitor — quota, session cost, top tools, usage insights |
+| Crypto / DeFi | [`crypto-defi.json`](mcp-configs/crypto-defi.json) | defi-mcp, Filesystem, Fetch, Memory |
+| Data Science | [`data-science.json`](mcp-configs/data-science.json) | Jupyter, SQLite, PostgreSQL, Filesystem |
+| Design | [`design.json`](mcp-configs/design.json) | Figma design context, Blender 3D automation |
+| DevOps | [`devops.json`](mcp-configs/devops.json) | AWS, Docker, GitHub, Terraform, Sentry |
+| E-Commerce | [`ecommerce.json`](mcp-configs/ecommerce.json) | BuyWhere product search, price comparison, deal discovery across 1M+ products |
+| Finance | [`finance.json`](mcp-configs/finance.json) | Helium news/markets/options, Chart Library pattern intelligence, Fetch, Memory |
+| Frontend | [`frontend.json`](mcp-configs/frontend.json) | Puppeteer, Figma, Storybook |
 | Full Stack | [`fullstack.json`](mcp-configs/fullstack.json) | Filesystem, GitHub, Postgres, Redis, Puppeteer |
 | Kubernetes | [`kubernetes.json`](mcp-configs/kubernetes.json) | kubectl-mcp-server, Docker, GitHub |
-| Data Science | [`data-science.json`](mcp-configs/data-science.json) | Jupyter, SQLite, PostgreSQL, Filesystem |
-| Frontend | [`frontend.json`](mcp-configs/frontend.json) | Puppeteer, Figma, Storybook |
-| Crypto / DeFi | [`crypto-defi.json`](mcp-configs/crypto-defi.json) | defi-mcp, Filesystem, Fetch, Memory |
-| DevOps | [`devops.json`](mcp-configs/devops.json) | AWS, Docker, GitHub, Terraform, Sentry |
-| Research | [`research.json`](mcp-configs/research.json) | BGPT scientific papers, Brave Search, Fetch, Memory, Filesystem |
-| Observability | [`observability.json`](mcp-configs/observability.json) | Iris eval & observability for agent tracing, quality evaluation, and cost tracking |
-| Security | [`security.json`](mcp-configs/security.json) | Ghidra reverse engineering, Snyk vulnerability scanning |
-| Design | [`design.json`](mcp-configs/design.json) | Figma design context, Blender 3D automation |
-| Workflow Automation | [`workflow-automation.json`](mcp-configs/workflow-automation.json) | n8n workflow builder, Pipedream integration |
-| Mobile | [`mobile.json`](mcp-configs/mobile.json) | Android ADB automation, Xcode build tools |
-| Finance | [`finance.json`](mcp-configs/finance.json) | Helium news/markets/options, Chart Library pattern intelligence, Fetch, Memory |
-| E-Commerce | [`ecommerce.json`](mcp-configs/ecommerce.json) | BuyWhere product search, price comparison, deal discovery across 1M+ products |
 | LLM Cost | [`llm-cost.json`](mcp-configs/llm-cost.json) | llm-prices: look up and compare API costs across 167 models from 23 providers before making calls |
+| Mobile | [`mobile.json`](mcp-configs/mobile.json) | Android ADB automation, Xcode build tools |
+| Observability | [`observability.json`](mcp-configs/observability.json) | Iris eval & observability for agent tracing, quality evaluation, and cost tracking |
+| Research | [`research.json`](mcp-configs/research.json) | BGPT scientific papers, Brave Search, Fetch, Memory, Filesystem |
+| Security | [`security.json`](mcp-configs/security.json) | Ghidra reverse engineering, Snyk vulnerability scanning |
+| Workflow Automation | [`workflow-automation.json`](mcp-configs/workflow-automation.json) | n8n workflow builder, Pipedream integration |
 
 ---
 
@@ -1003,7 +1004,7 @@ claude-code-toolkit/               850+ files
     scripts/                       19 Node.js scripts
   rules/                           15 coding rules
   templates/claude-md/             7 CLAUDE.md templates
-  mcp-configs/                     8 server configurations
+  mcp-configs/                     17 server configurations
   contexts/                        5 context modes
   examples/                        3 walkthrough examples
   setup/                           Interactive installer

--- a/mcp-configs/claudestat.json
+++ b/mcp-configs/claudestat.json
@@ -1,0 +1,18 @@
+{
+  "mcpServers": {
+    "claudestat": {
+      "command": "npx",
+      "args": ["-y", "@statforge/claudestat"],
+      "description": "Real-time Claude Code monitor. Query quota status, session cost, top tools, usage insights, model breakdown, and weekly statistics directly from inside Claude Code. No setup required — starts instantly.",
+      "tools": [
+        "get_quota_status",
+        "get_current_session",
+        "get_session_stats",
+        "get_top_tools",
+        "get_usage_insights",
+        "get_model_breakdown",
+        "get_weekly_insight"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds [claudestat](https://github.com/DeibyGS/claudestat) as a new MCP config entry.

claudestat is a local daemon that tracks Claude Code and OpenCode sessions and exposes an MCP server so Claude can query its own usage mid-session.

### MCP Tools included
- `get_quota_status` — 5h cycle usage %, burn rate
- `get_current_session` — latest session cost, tokens, loops
- `get_session_stats` — aggregated stats for N days
- `get_top_tools` — top 10 tools by cost/count/duration
- `get_usage_insights` — cost per project, cache savings, peak hours
- `get_model_breakdown` — usage broken down by Claude model
- `get_weekly_insight` — weekly summary with actionable tip

**Install**: `npm install -g @statforge/claudestat`
**GitHub**: https://github.com/DeibyGS/claudestat

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Claudestat MCP server providing quota status, session management, usage statistics, and analytics tools.

* **Documentation**
  * Updated README to reflect the expanded set of available MCP server configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->