### PR TITLE
Add Weaver

### DIFF
--- a/README.md
+++ b/README.md
@@ -1162,6 +1162,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [voidly-mcp-server](https://github.com/voidly-ai/mcp-server) | new | 116 tools for Claude Code covering censorship intelligence (19.6M OONI measurements, 126 countries), E2E encrypted agent-to-agent messaging, and agent payments. Install: `claude mcp add voidly -- npx -y @voidly/mcp-server` |
 | [systemprompt-template](https://github.com/systempromptio/systemprompt-template) | -- | Governance infrastructure for Claude Code. Single compiled Rust binary that authenticates, authorises, rate-limits, logs, and attributes costs for every AI interaction before it reaches a tool or database. Self-hosted, air-gap capable, MCP + A2A compatible. BSL-1.1 |
 | [llm-prices](https://github.com/benbencodes/llm-prices) | new | CLI + Python library + MCP server to look up and compare LLM API costs across 167 models from 23 providers (OpenAI, Anthropic, Google, xAI, DeepSeek, Groq, and more). Ask Claude "what's the cheapest model for 10k input + 2k output?" before making API calls. Zero deps, no API key. `pipx install git+https://github.com/benbencodes/llm-prices` |
+| [Weaver](https://github.com/sean35mm/weaver) | new | Local coordination CLI for multiple coding agents in one repo. Agents announce tasks, claim paths/globs, check overlaps, and leave shared notes through a repo-local SQLite store. Works across Claude Code, Codex, OpenCode, and Pi. MIT. |
 
 ---
 


### PR DESCRIPTION
Adds Weaver to the Ecosystem table.\n\nWeaver is a local coordination CLI for multiple coding agents working in the same repo. It fits the ecosystem section because it gives Claude Code and other CLI agents shared repo-local state: task announcements, path/glob claims, overlap checks, and shared notes via SQLite.\n\nIt works across Claude Code, Codex, OpenCode, and Pi, and is MIT licensed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Documentation**
- Added Weaver to the Ecosystem listings table, including its GitHub link and description of its local coordination CLI functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->