### PR TITLE
Add polyhook to Hooks > Related SDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -837,6 +837,7 @@ Twenty hook scripts covering all eight Claude Code lifecycle events. Place `hook
 If you prefer a typed, npm-installable foundation for writing hooks rather than raw scripts:
 
 - [claude-code-hooks](https://github.com/Payshak/claude-code-hooks) — TypeScript SDK with `defineHook()`, typed event payloads for all 5 hook events, response builders, and unit-testable `.handle()` method. Zero dependencies.
+- [polyhook](https://github.com/tupe12334/polyhook) — Multi-language SDK (TypeScript, Rust, Go, Python, .NET) for writing AI coding agent hooks that run unchanged across Claude Code, Cursor, Windsurf, Cline, and Amp. Rust core compiled to WASM.
 - [EchoCoding](https://github.com/launsion-boop/EchoCoding) — Audio layer for coding agents with hook-triggered SFX, ambient soundscape, and optional cloud TTS/ASR voice interaction. Works with Claude Code hooks and also supports Cursor/Windsurf, Codex CLI, and Gemini CLI.
 
 ### Installing Hooks


### PR DESCRIPTION
Closes #492

## What
Adds [polyhook](https://github.com/tupe12334/polyhook) to the **Hooks → Related SDKs** subsection.

## Why it fits
- Multi-language SDK (TypeScript, Rust, Go, Python, .NET) for writing AI coding agent hooks
- Hooks run unchanged across Claude Code, Cursor, Windsurf, Cline, and Amp — solves the cross-tool format fragmentation problem
- Rust core compiled to WASM
- Complements existing `claude-code-hooks` entry (TypeScript-only, Claude Code-only) as the cross-tool, multi-language alternative

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added polyhook to the Related SDKs section—a multi-language SDK (TypeScript, Rust, Go, Python, .NET) for writing AI coding agent hooks that run across multiple Claude Code-compatible client implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->