### PR TITLE
Add the-perfect-orchestrator to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1206,6 +1206,7 @@ Tutorials, guides, and deep-dives on Claude Code.
 | [awesome-claude-design](https://github.com/rohitg00/awesome-claude-design) | ![Stars](https://img.shields.io/github/stars/rohitg00/awesome-claude-design?style=flat-square&label=) | DESIGN.md files grouped by aesthetic family (editorial, terminal, warm, data-dense, cinematic, playful, glass, brutalist, indie) + remix recipes + prompt packs for Claude Design (Anthropic Labs) |
 | [ai-skill](https://github.com/anomalyco/ai-skill) | - | AI skill discovery and management system - helps users find, evaluate, install and manage agent skills, tools, plugins and extensions |
 | [Awesome AI Startups](https://github.com/nowork-studio/awesome-ai-startups) | new | Curated directory of ~440 indie-built AI products (bootstrapped, pre-seed, angel-funded) across 18 categories — AI agents, coding tools, marketing, audio/voice, image/design, video, and more |
+| [the-perfect-orchestrator](https://github.com/daman8271/the-perfect-orchestrator) | new | One lead Claude Code session commands N autonomous workers in tmux panes — spawns, briefs, monitors, then adversarially verifies results. Pure bash + tmux, zero daemons, coordination via plain files. Also installable as a plugin shipping the `/orch` skill. MIT |
 
 ## Contributing
 


### PR DESCRIPTION
Adds [the-perfect-orchestrator](https://github.com/daman8271/the-perfect-orchestrator) to the Ecosystem table (Stars column "new" — it is).

One lead Claude Code session spawns, briefs, monitors and adversarially verifies N autonomous worker sessions in tmux. Pure bash + tmux, zero daemons; also a Claude Code plugin shipping `/orch`. MIT.

Full disclosure: v0.2.0, days old, I'm the author. Recorded real fleet run with raw transcripts: [docs/realrun-2026-06-06](https://github.com/daman8271/the-perfect-orchestrator/tree/main/docs/realrun-2026-06-06).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new entry to the Related Awesome Lists section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->