### PR TITLE
feat: add TWZRD Agent Intel to Companion Apps section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1162,6 +1162,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [voidly-mcp-server](https://github.com/voidly-ai/mcp-server) | new | 116 tools for Claude Code covering censorship intelligence (19.6M OONI measurements, 126 countries), E2E encrypted agent-to-agent messaging, and agent payments. Install: `claude mcp add voidly -- npx -y @voidly/mcp-server` |
 | [systemprompt-template](https://github.com/systempromptio/systemprompt-template) | -- | Governance infrastructure for Claude Code. Single compiled Rust binary that authenticates, authorises, rate-limits, logs, and attributes costs for every AI interaction before it reaches a tool or database. Self-hosted, air-gap capable, MCP + A2A compatible. BSL-1.1 |
 | [llm-prices](https://github.com/benbencodes/llm-prices) | new | CLI + Python library + MCP server to look up and compare LLM API costs across 167 models from 23 providers (OpenAI, Anthropic, Google, xAI, DeepSeek, Groq, and more). Ask Claude "what's the cheapest model for 10k input + 2k output?" before making API calls. Zero deps, no API key. `pipx install git+https://github.com/benbencodes/llm-prices` |
+| [TWZRD Agent Intel](https://intel.twzrd.xyz) | -- | Solana-native x402 MCP for agent trust scoring -- 4 free preflight tools score any Solana wallet (on-chain activity, transaction patterns, network age, recurring behavior); 4 paid tools return signed `twzrd.receipt.v5` trust tokens via HTTP 402 + USDC on Solana, <1s settlement. First Solana-native x402 MCP. MCP Registry: `xyz.twzrd.intel/twzrd-agent-intel`. |
 
 ---
 


### PR DESCRIPTION
## What

Adds **[TWZRD Agent Intel](https://intel.twzrd.xyz)** to the Companion Apps & GUIs section.

## Why it fits

TWZRD Agent Intel is a production Solana MCP server that enables agent-to-agent trust verification via x402 micropayments — relevant to the Claude Code ecosystem as an identity/trust layer for autonomous agents:

- **4 free tools**: Preflight trust scoring for any Solana wallet (on-chain activity, transaction patterns, network age, recurring behavior patterns)
- **4 paid tools**: HTTP 402 flow → USDC settlement on Solana (<1s) → signed `twzrd.receipt.v5` trust token
- **MCP Registry**: Listed at `xyz.twzrd.intel/twzrd-agent-intel` on the official MCP Registry
- **Transport**: Streamable-HTTP at `https://intel.twzrd.xyz/mcp`

Natural neighbor to the `voidly-mcp-server` (agent payments) and `systemprompt-template` (agent governance) entries already in this section. The trust receipt pattern is useful when Claude Code agents interact with other autonomous agents and need to verify wallet/identity trustworthiness before transacting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added TWZRL Agent Intel to the Ecosystem section, highlighting its Solana-native MCP for agent trust scoring, including free preflight tools and paid receipt-based trust tokens with registry link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->