### PR TITLE
Add obsidian-chronicle plugin (auto Obsidian session journaling)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Over 176 production-ready plugins that extend Claude Code with domain-specific c
 
 | Plugin | Description |
 |--------|-------------|
+| [obsidian-chronicle](https://github.com/takashito/claude-obsidian-chronicle) | Auto-records every Claude Code session as a structured Obsidian note + a Daily Note line via SessionEnd/PreCompact/`/done` hooks. Resume-aware — appends to the same note (matched by session_id), no duplicates. Pure bash + jq, no daemon. Install: `/plugin marketplace add takashito/claude-obsidian-chronicle` |
 | [agento-patronum](https://github.com/emaarco/agento-patronum) | Protects sensitive files, credentials, and shell commands from unintended AI access via Claude Code hooks. Unlike settings.json deny rules, hooks are an enforcement layer you own and can verify. Ships with defaults for .env files, SSH keys, AWS credentials, and kubeconfig. |
 | [skills-janitor](https://github.com/khendzel/skills-janitor) | Audit, deduplicate, check, fix, and track usage of your Claude Code skills. 9 slash commands, zero dependencies |
 | [great_cto](https://github.com/avelikiy/great_cto) | Full SDLC pipeline plugin with 7 agents (tech-lead, senior-dev, qa-engineer, security-officer, devops, l3-support, project-auditor), 12-angle code review, 10 project archetypes, 13 compliance frameworks (SOC2/HIPAA/PCI-DSS/GDPR/ISO 27001), two-gate approval flow. Opus 4.7 advisor escalation, file-based, MIT |


### PR DESCRIPTION
Adds **obsidian-chronicle** to the *All Plugins* table.

[obsidian-chronicle](https://github.com/takashito/claude-obsidian-chronicle) is a Claude Code plugin that auto-records every coding session as a structured Obsidian note + a Daily Note line, triggered by `SessionEnd` / `PreCompact` / `/done` hooks (nothing to run manually).

What makes it different:
- **Resume-aware** — resuming a session appends to the *same* note (matched by `session_id`), so one task = one note, no duplicates.
- **PreCompact capture** — long sessions are recorded before auto-compact discards context.
- Native Obsidian output: frontmatter, callouts, a Files-Changed table, `[[wikilinks]]`, Daily Note integration.
- Pure bash + jq — no daemon, no Python, no build step. MIT.

Install: `/plugin marketplace add takashito/claude-obsidian-chronicle`

One-line addition to the README table; entry links to the external repo (same style as other external entries in the list).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added obsidian-chronicle plugin to the featured plugins listing with GitHub link and installation instructions for session recording functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->