### PR TITLE
feat: add The Stall — 210 pay-per-call AI capabilities via x402 (MCP)

### DIFF
--- a/mcp-configs/finance.json
+++ b/mcp-configs/finance.json
@@ -6,17 +6,30 @@
     },
     "chart-library": {
       "command": "python",
-      "args": ["-m", "chartlibrary_mcp"],
+      "args": [
+        "-m",
+        "chartlibrary_mcp"
+      ],
       "description": "Historical chart pattern search engine. Search 24M+ pre-computed embeddings across 15K+ symbols and 10 years of data. 19 tools for pattern matching, forward returns, regime analysis, anomaly detection, and trading signals. Free tier: 200 calls/day, no signup. Install: pip install chartlibrary-mcp"
+    },
+    "the-stall": {
+      "url": "https://the-stall.intuitek.ai/mcp",
+      "description": "Remote MCP server with 173 financial tools \u2014 US stocks/options/ETFs, analyst ratings, earnings calendars, SEC/insider filings, crypto/DeFi (DEX quotes, funding rates, DeFi yields), macro indicators, Polymarket prediction markets, congressional trades. No API key: agents pay $0.002\u2013$0.35 USDC via x402."
     },
     "fetch": {
       "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-fetch"],
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-fetch"
+      ],
       "description": "Fetch financial news, SEC filings, and market data from web sources."
     },
     "memory": {
       "command": "npx",
-      "args": ["-y", "@modelcontextprotocol/server-memory"],
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-memory"
+      ],
       "description": "Track trade ideas, watchlists, and analysis findings across sessions."
     }
   }


### PR DESCRIPTION
## What this adds

Adds **The Stall** (`the-stall`) as a remote MCP server to the Finance config.

**URL:** `https://the-stall.intuitek.ai/mcp`

## Why

The Stall is a remote MCP server with **198 financial tools** — no API key required. Agents pay per call in USDC via [x402](https://x402.org) (typically $0.001–$0.035/call). No subscriptions, no rate limits, no key rotation.

### Tools included

| Category | Example tools |
|----------|--------------|
| US Equities | `us-stock-price`, `equity-brief`, `equity-fundamentals`, `equity-technicals`, `stock-ohlcv` |
| Options | `options-chain`, `options-snapshot` |
| Earnings & Filings | `earnings-calendar`, `earnings-surprises`, `sec-filing-intel`, `sec-insider-trades` |
| Congressional | `congressional-trades`, `gov-votes` |
| Crypto / DeFi | `dex-swap-quote`, `dex-yields`, `funding-rates`, `defi-market-pulse`, `crypto-pulse` |
| Macro | `fomc-tracker`, `treasury-yields`, `economic-calendar`, `macro-brief` |
| Korean markets | `korean-market-movers` (Upbit KRW pairs) |
| Prediction Markets | `polymarket-intel`, `prediction-markets` |
| Sentiment | `equity-sentiment`, `news-sentiment`, `market-intelligence` |

## How to use

No setup needed — add the URL to your MCP config and any compatible agent can call it:

```json
{
  "mcpServers": {
    "the-stall": {
      "url": "https://the-stall.intuitek.ai/mcp"
    }
  }
}
```

Browse the full catalog: https://the-stall.intuitek.ai/catalog

GitHub: https://github.com/thebrierfox/the-stall
