### PR TITLE
feat: add ProposalCraft to Ecosystem — MCP server for freelance proposal drafting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1162,6 +1162,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [voidly-mcp-server](https://github.com/voidly-ai/mcp-server) | new | 116 tools for Claude Code covering censorship intelligence (19.6M OONI measurements, 126 countries), E2E encrypted agent-to-agent messaging, and agent payments. Install: `claude mcp add voidly -- npx -y @voidly/mcp-server` |
 | [systemprompt-template](https://github.com/systempromptio/systemprompt-template) | -- | Governance infrastructure for Claude Code. Single compiled Rust binary that authenticates, authorises, rate-limits, logs, and attributes costs for every AI interaction before it reaches a tool or database. Self-hosted, air-gap capable, MCP + A2A compatible. BSL-1.1 |
 | [llm-prices](https://github.com/benbencodes/llm-prices) | new | CLI + Python library + MCP server to look up and compare LLM API costs across 167 models from 23 providers (OpenAI, Anthropic, Google, xAI, DeepSeek, Groq, and more). Ask Claude "what's the cheapest model for 10k input + 2k output?" before making API calls. Zero deps, no API key. `pipx install git+https://github.com/benbencodes/llm-prices` |
+| [ProposalCraft](https://github.com/jabbawocky/proposalcraft) | new | MCP server for freelancers and consultants. Paste a client brief → get a proposal drafted in your voice from past winning work. Analyzes briefs for budget signals, red flags, and scope risks before you commit. Free tier (5 drafts/month), no API key required. `npx -y github:jabbawocky/proposalcraft` |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Claude Code Toolkit
 
-**The most comprehensive toolkit for Claude Code -- 135 agents, 35 curated skills (+400,000 via [SkillKit](https://agenstskills.com)), 42 commands, 176+ plugins, 20 hooks, 15 rules, 7 templates, 15 MCP configs, 26 companion apps, 53 ecosystem entries, and more.**
+**The most comprehensive toolkit for Claude Code -- 135 agents, 35 curated skills (+400,000 via [SkillKit](https://agenstskills.com)), 42 commands, 176+ plugins, 20 hooks, 15 rules, 7 templates, 15 MCP configs, 26 companion apps, 54 ecosystem entries, and more.**
 
 <p align="center">
   <a href="https://trendshift.io/repositories/21839" target="_blank"><img src="https://trendshift.io/api/badge/repositories/21839" alt="rohitg00%2Fawesome-claude-code-toolkit | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>


### PR DESCRIPTION
## What

Adds [ProposalCraft](https://github.com/jabbawocky/proposalcraft) to the Ecosystem section.

## Why it fits

ProposalCraft is an MCP server that Claude Code users can add to draft client proposals in their own voice from past winning work. It's a real-world, production-ready tool that extends Claude Code into the freelance/consulting workflow — fitting alongside the other ecosystem entries.

**Key facts:**
- Install: `npx -y github:jabbawocky/proposalcraft` (no API key)
- 8 MCP tools: `analyze_brief`, `draft_proposal`, `save_proposal`, `usage_status`, and more
- Free tier: 5 drafts/month · Pro: unlimited
- Works with Claude Desktop and Claude Code
- TypeScript, MIT license
- Launching on Product Hunt June 10, 2026

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated toolkit stats to reflect 54 ecosystem entries (previously 53).
  * Added a new ProposalCraft ecosystem entry with description, GitHub link, and installation command for quick setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->