### PR TITLE
Add fluiddocs-deck-builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Over 176 production-ready plugins that extend Claude Code with domain-specific c
 
 | Plugin | Description |
 |--------|-------------|
+| [fluiddocs-deck-builder](https://github.com/FluidForm-ai/fluiddocs-deck-builder) | Builds single-file, type-correct HTML decks from a one-line brief, with PDF/PPTX import and inline editing. MIT, works with Codex and Gemini CLI. |
 | [agento-patronum](https://github.com/emaarco/agento-patronum) | Protects sensitive files, credentials, and shell commands from unintended AI access via Claude Code hooks. Unlike settings.json deny rules, hooks are an enforcement layer you own and can verify. Ships with defaults for .env files, SSH keys, AWS credentials, and kubeconfig. |
 | [skills-janitor](https://github.com/khendzel/skills-janitor) | Audit, deduplicate, check, fix, and track usage of your Claude Code skills. 9 slash commands, zero dependencies |
 | [great_cto](https://github.com/avelikiy/great_cto) | Full SDLC pipeline plugin with 7 agents (tech-lead, senior-dev, qa-engineer, security-officer, devops, l3-support, project-auditor), 12-angle code review, 10 project archetypes, 13 compliance frameworks (SOC2/HIPAA/PCI-DSS/GDPR/ISO 27001), two-gate approval flow. Opus 4.7 advisor escalation, file-based, MIT |


### PR DESCRIPTION
Single-purpose, tested plugin. Adds one row to the All Plugins table linking the external repo. No generated attribution footer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added fluiddocs-deck-builder plugin to the plugins reference with GitHub repository link and description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->