### PR TITLE
Add Poppify — Claude Code plugin for short-form vertical video

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ Over 176 production-ready plugins that extend Claude Code with domain-specific c
 | [perf-profiler](plugins/perf-profiler/) | Performance analysis, profiling, and optimization recommendations |
 | [performance-monitor](plugins/performance-monitor/) | Profile API endpoints and run benchmarks to identify performance bottlenecks |
 | [plan](plugins/plan/) | Structured planning with risk assessment and time estimation |
+| [poppify](https://github.com/Poppify/poppify-claude-plugin) | Photo-led short-form vertical reels for Instagram / TikTok / YouTube Shorts / Facebook. Upload 1–10 photos, get a captioned 15/30/60s reel with motion, library-matched music, optional voiceover. 27 MCP tools + 4 skills + 3 slash commands. $0.06 base render, 50 free seeds, no subscription. Drop-in replacement for Runway when you have photos. Install: `/plugin marketplace add Poppify/poppify-claude-plugin` then `/plugin install poppify@poppify` |
 | [preflight](https://github.com/preflight-dev/preflight) | 24-tool MCP server that catches vague prompts before they cost 2-3x in wrong→fix cycles. 12-category scorecards, correction pattern learning, cross-service contract awareness, session history search with LanceDB vectors, and cost estimation. `npx preflight-dev` |
 | [pr-reviewer](plugins/pr-reviewer/) | Review pull requests with structured analysis and approve with confidence |
 | [product-shipper](plugins/product-shipper/) | Ship features end-to-end with launch checklists and rollout plans |


### PR DESCRIPTION
## Summary

Adds [Poppify](https://github.com/Poppify/poppify-claude-plugin) as a single alphabetically-sorted row in the **All Plugins** table (between \`plan\` and \`preflight\`).

Poppify is a Claude Code plugin for photo-led vertical reels — Instagram / TikTok / YouTube Shorts / Facebook. Upload 1–10 photos, get a captioned 15/30/60s reel with motion, library-matched music, and optional voiceover.

## What's bundled in the plugin

- **MCP server** (https://poppify.ai/mcp, HTTP) — 27 tools
- **4 skills** — \`poppify-build-reel\`, \`poppify-render-debug\`, \`poppify-troubleshoot\`, \`poppify-schema-introspect\`
- **3 slash commands** — \`/poppify:make-reel\`, \`/poppify:troubleshoot\`, \`/poppify:verify-render\`

## Cost transparency

- Plugin install + 22 of the 27 MCP tools: **free**
- \`confirm\` render: 1 seed (~$0.06)
- \`generate_image\` / \`generate_music\` / \`generate_voiceover\`: 10 seeds each
- 50 free seeds granted on signup. No subscription.

## Positioning

The creative slot in an agentic marketing stack for SMBs (5–19 employees) and solo service providers. Drop-in replacement for Runway when you have source photos and want library-matched audio; pairs with Postiz for scheduling and Windsor.ai for attribution.

**Not for:** text→video generation (use Runway/Sora/Veo), avatar-based video (use HeyGen/Synthesia), 4K horizontal, sub-4s clips.

## Test plan

- [x] Single-row addition, sorted alphabetically (P comes after plan, before preflight)
- [x] 2-column format matches All Plugins table
- [x] Description includes install command per repo convention
- [x] Plugin metadata matches what's claimed (verified against canonical \`Poppify/poppify-claude-plugin\` README)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the poppify-claude-plugin entry to the plugins list with description and installation instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->