### PR TITLE
Add ccline - zsh natural language shell integration using Claude CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1067,6 +1067,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 
 | Name | Stars | Description |
 |------|-------|-------------|
+| [ccline](https://github.com/jianshuo/ccline) | new | zsh shell integration: type a natural-language thought directly at your prompt, get a Claude AI answer rendered as Markdown, and run any suggested commands with one keypress. Hijacks `command_not_found_handler` — one word stays a typo, two+ words become a query. `curl -fsSL https://raw.githubusercontent.com/jianshuo/ccline/v0.2.2/install.sh | bash` |
 | [claude-mem](https://github.com/thedotmack/claude-mem) | 35,900+ | Auto-captures everything Claude does, compresses with AI, injects context into future sessions. #1 trending GitHub Feb 2026 |
 | [wshobson/agents](https://github.com/wshobson/agents) | 31,300+ | 112 specialized agents, 16 orchestrators, 146 skills, 79 tools in 72 focused plugins |
 | [oh-my-claudecode](https://github.com/Yeachan-Heo/oh-my-claudecode) | 9,900+ | Teams-first multi-agent orchestration with 19 specialized agents and 28 skills |


### PR DESCRIPTION
## What is ccline?

[ccline](https://github.com/jianshuo/ccline) brings Claude Code's intelligence directly to your zsh prompt — no window switching, no prefix needed.

**How it works:** Type a natural-language thought directly at your zsh prompt (two or more words). ccline hijacks `command_not_found_handler` to send your query to Claude (or Codex as fallback). The answer is rendered as Markdown. If it contains shell commands, an arrow-key menu lets you run them in your live shell — so `cd`, `export`, aliases, and history all persist.

```
$ how do I find files bigger than 100MB here

    find . -maxdepth 1 -type f -size +100M

Commands found — ↑/↓ to choose, Enter to run, q to cancel:
 ❯ find . -maxdepth 1 -type f -size +100M
   find . -type f -size +100M
   ➤ Run all of them
   ✗ Cancel
```

**Install:**
```bash
curl -fsSL https://raw.githubusercontent.com/jianshuo/ccline/v0.2.2/install.sh | bash
```

**Why it fits in Ecosystem:** ccline is a shell-layer companion for Claude Code users — it extends Claude Code's reach to your everyday terminal workflow, using the same `claude` CLI that Claude Code installs.

Fits the Ecosystem section as a standalone tool that integrates with the Claude CLI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added ccline to the Ecosystem table in README with its installation command, feature description highlighting zsh shell integration support, and marking to identify new entries. Developers can now quickly browse the expanded ecosystem section to discover additional tools and solutions for enhancing their development environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->