### PR TITLE
Add Cate to Companion Apps & GUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1058,6 +1058,7 @@ claude-code-toolkit/               850+ files
 | [cctally](https://github.com/omrikais/cctally) | new | Track Claude Code subscription usage as a weekly $-per-1% trend. Local web dashboard, terminal UI, forecasts, threshold alerts. Apache-2.0, zero telemetry. |
 | [claude-code-notifier](https://github.com/saiso/claude-code-notifier) | new | Native macOS notifier for Claude Code. Swift + UserNotifications, custom Heroicons-derived icon (SF Symbols–free), click-through to your IDE (VS Code, Cursor, Windsurf, JetBrains, iTerm2, Terminal) via bundle ID swap, per-event sound labels, hardened inputs (allowlists, length caps, control-character stripping). Universal binary (arm64 + x86_64), macOS 12+, MIT |
 | [ToutKit](https://github.com/toutkit/toutkit) | new | Desktop notebook for AI CLIs (Claude Code, Codex, Gemini). Pairs a sidebar of notes with a built-in terminal and an in-app webview that renders whatever the AI writes — each note is a self-contained folder with its own SQLite, key/value store, attached files, and scripts, so a note can grow from a static page into a sortable table, dashboard, or research tool. Local-first, AGPL-3.0 |
+| [Cate](https://github.com/0-AI-UG/cate) | 1,200+ | Open source desktop IDE on an infinite zoomable canvas. Arrange Monaco editors, xterm terminals, embedded browsers, and Claude Code agent panels in spatial workspace instead of tabs. Panels float, dock into splits, or detach into separate windows; layout persists per project. Electron, MIT, macOS/Windows/Linux |
 
 ---
 


### PR DESCRIPTION
Adds Cate to the Companion Apps & GUIs table. Cate is an open source desktop IDE (Electron + React + TypeScript, MIT) built on an infinite canvas, with built-in Claude Code agent panels alongside editors, terminals, and browsers. 1,200+ stars, actively developed. Website: https://cate.cero-ai.com


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Cate to the Companion Apps & GUIs list—a new infinite zoomable canvas IDE featuring Electron support and cross-platform availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->