### PR TITLE
Add Headroom to Companion Apps — macOS menu bar Claude Code usage meter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1027,6 +1027,7 @@ claude-code-toolkit/               850+ files
 | [parallel-code](https://github.com/johannesjo/parallel-code) | 370+ | Run Claude Code, Codex, and Gemini side by side -- each in its own git worktree |
 | [Bernstein](https://github.com/sipyourdrink-ltd/bernstein) | 288 | Python orchestrator for 40+ CLI coding agents (Claude Code, Codex, Gemini CLI). Git worktree isolation, MCP server mode, HMAC audit trail. Plan-driven, deterministic. Apache-2.0 |
 | [Poirot](https://github.com/LeonardoCardoso/Poirot) | 96 | macOS app for browsing Claude Code sessions, viewing diffs, and re-running commands. Reads local transcripts, runs offline |
+| [Headroom](https://github.com/patwalls/headroom) | new | Native macOS menu bar app showing Claude Code session (5h) + weekly (7d) utilization as a live %. Zero network calls — reads the file Claude Code's own statusLine hook writes. Free, MIT. [headroom.walls.sh](https://headroom.walls.sh) |
 | [TokenEater](https://github.com/AThevon/TokenEater) | 179 | Native macOS menu bar app for monitoring Claude AI usage limits and watching coding sessions live |
 | [Claw](https://github.com/jamesrochabrun/Claw) | 86 | Native macOS app wrapping Claude Code SDK in Swift. Plan Mode, MCP Integration, Custom System Prompts |
 | [The Claude Protocol](https://github.com/AvivK5498/The-Claude-Protocol) | 149 | Enforcement layer wrapping Claude Code with 13 hooks -- blocks unsafe operations, enforces worktree isolation |


### PR DESCRIPTION
## What

Adds [Headroom](https://github.com/patwalls/headroom) to the Companion Apps & GUIs section.

## Description

Headroom is a native macOS menu bar app showing Claude Code session (5h) + weekly (7d) utilization as a live %, color-coded as limits approach. It reads data from the file Claude Code's own statusLine hook writes — **zero network calls, zero API keys, zero Keychain access** on the happy path. Free, MIT-licensed, ~265 KB.

- Site: https://headroom.walls.sh
- GitHub: https://github.com/patwalls/headroom
- Install: download from site or `brew install --cask patwalls/tap/headroom`

## Why it belongs here

It's a macOS companion app specifically built for Claude Code usage monitoring — same category as TokenEater, cc-token-status, WhereMyTokens, and cctally already in the list. The differentiator is the zero-network architecture: rather than polling the API, Headroom uses Claude Code's statusLine hook so it can never cause rate-limit issues and requires no credentials setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Headroom (Native macOS menu bar app) to the companion applications list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->