### PR TITLE
Add AugmentClaude: free hand-picked directory of Claude Code skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -1162,6 +1162,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [voidly-mcp-server](https://github.com/voidly-ai/mcp-server) | new | 116 tools for Claude Code covering censorship intelligence (19.6M OONI measurements, 126 countries), E2E encrypted agent-to-agent messaging, and agent payments. Install: `claude mcp add voidly -- npx -y @voidly/mcp-server` |
 | [systemprompt-template](https://github.com/systempromptio/systemprompt-template) | -- | Governance infrastructure for Claude Code. Single compiled Rust binary that authenticates, authorises, rate-limits, logs, and attributes costs for every AI interaction before it reaches a tool or database. Self-hosted, air-gap capable, MCP + A2A compatible. BSL-1.1 |
 | [llm-prices](https://github.com/benbencodes/llm-prices) | new | CLI + Python library + MCP server to look up and compare LLM API costs across 167 models from 23 providers (OpenAI, Anthropic, Google, xAI, DeepSeek, Groq, and more). Ask Claude "what's the cheapest model for 10k input + 2k output?" before making API calls. Zero deps, no API key. `pipx install git+https://github.com/benbencodes/llm-prices` |
+| [AugmentClaude](https://augmentclaude.com) | new | Free hand-picked directory of Claude Code skills, bundles, MCP servers, and agents — every entry credited to its original author |
 
 ---
 


### PR DESCRIPTION
Adds one row at the end of the **Ecosystem** table, following the existing format (`new` in the stars column, factual description).

[AugmentClaude](https://augmentclaude.com) is a free, hand-picked directory of Claude Code skills, bundles, MCP servers, and agents. Every entry is credited to its original author with a link to the GitHub source.

Disclosure: I'm the founder. Happy to adjust wording or placement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added AugmentClaude to the Ecosystem section, a free directory of Claude Code skills, bundles, MCP servers, and agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->