### PR TITLE
Add Citadel to All Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Over 176 production-ready plugins that extend Claude Code with domain-specific c
 
 | Plugin | Description |
 |--------|-------------|
+| [Citadel](https://github.com/SethGammon/Citadel) | Agent orchestration layer for Claude Code and OpenAI Codex: durable campaign memory, /do intent routing, 46 skills, lifecycle safety hooks, cost telemetry, and parallel agents in isolated git worktrees. Zero dependencies, MIT. |
 | [agento-patronum](https://github.com/emaarco/agento-patronum) | Protects sensitive files, credentials, and shell commands from unintended AI access via Claude Code hooks. Unlike settings.json deny rules, hooks are an enforcement layer you own and can verify. Ships with defaults for .env files, SSH keys, AWS credentials, and kubeconfig. |
 | [skills-janitor](https://github.com/khendzel/skills-janitor) | Audit, deduplicate, check, fix, and track usage of your Claude Code skills. 9 slash commands, zero dependencies |
 | [great_cto](https://github.com/avelikiy/great_cto) | Full SDLC pipeline plugin with 7 agents (tech-lead, senior-dev, qa-engineer, security-officer, devops, l3-support, project-auditor), 12-angle code review, 10 project archetypes, 13 compliance frameworks (SOC2/HIPAA/PCI-DSS/GDPR/ISO 27001), two-gate approval flow. Opus 4.7 advisor escalation, file-based, MIT |


### PR DESCRIPTION
Adds [Citadel](https://github.com/SethGammon/Citadel): an agent orchestration layer for Claude Code and OpenAI Codex with durable campaign memory, /do intent routing, 46 skills, lifecycle safety hooks, cost telemetry, and parallel agents in isolated git worktrees. MIT licensed, zero runtime dependencies.

Quality signals: 55-check test suite in CI, security scanner gate (HOL Plugin Scanner, 98/100 A grade with no elevated findings), interactive routing demo at https://sethgammon.github.io/Citadel/ and both .claude-plugin and .codex-plugin manifests in the repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the Citadel plugin to the plugins directory, including its link and description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->