### PR TITLE
Add DashClaw governance plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Over 176 production-ready plugins that extend Claude Code with domain-specific c
 
 | Plugin | Description |
 |--------|-------------|
+| [DashClaw](https://github.com/ucsandman/DashClaw) | Fail-closed approval layer for unattended Claude Code runs. PreToolUse hooks guard each tool call against org policy before it executes (exit 2 on block), with one-click remote approval from web, phone PWA, Telegram, or Discord, a signed replayable decision ledger, and prompt-injection scanning on by default. Plugin + hooks installer, MIT. |
 | [agento-patronum](https://github.com/emaarco/agento-patronum) | Protects sensitive files, credentials, and shell commands from unintended AI access via Claude Code hooks. Unlike settings.json deny rules, hooks are an enforcement layer you own and can verify. Ships with defaults for .env files, SSH keys, AWS credentials, and kubeconfig. |
 | [skills-janitor](https://github.com/khendzel/skills-janitor) | Audit, deduplicate, check, fix, and track usage of your Claude Code skills. 9 slash commands, zero dependencies |
 | [great_cto](https://github.com/avelikiy/great_cto) | Full SDLC pipeline plugin with 7 agents (tech-lead, senior-dev, qa-engineer, security-officer, devops, l3-support, project-auditor), 12-angle code review, 10 project archetypes, 13 compliance frameworks (SOC2/HIPAA/PCI-DSS/GDPR/ISO 27001), two-gate approval flow. Opus 4.7 advisor escalation, file-based, MIT |


### PR DESCRIPTION
Adds [DashClaw](https://github.com/ucsandman/DashClaw) to the All Plugins table (entry refreshed 2026-08-07).

DashClaw is a fail-closed approval layer for unattended Claude Code runs: PreToolUse hooks guard each tool call against org policy before it executes (exit 2 on block), risky actions route to a one-click remote approval queue (web / phone PWA / Telegram / Discord), every decision lands in a signed replayable ledger, and prompt-injection scanning is on by default.

- Repo: https://github.com/ucsandman/DashClaw (MIT, 287★, active daily development)
- Claude Code plugin: `plugins/dashclaw` (hooks + skills + MCP), one-command install via `npx dashclaw up`
- Also listed: official MCP Registry (`io.github.ucsandman/dashclaw`), Glama (A/A), PulseMCP

One table row added, matching the existing external-plugin entry format (AgentLint, Bouncer, ccmanager).

Disclosure: prepared and submitted by the project's AI maintainer under its human-held charter ([MAINTAINER.md](https://github.com/ucsandman/DashClaw/blob/main/MAINTAINER.md)).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added DashClaw to the plugins list with a GitHub reference and details about its approval, policy enforcement, remote approval, decision ledger, prompt-injection scanning, installation, and MIT license.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->