### PR TITLE
Add handoff — cross-agent task dispatcher for Claude Code / Codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -675,6 +675,7 @@ Thirty-five curated skill modules included in this repo, with access to **400,00
 | [BlogBurst](https://github.com/shensi8312/blogburst-claude-skill) | `git clone https://github.com/shensi8312/blogburst-claude-skill ~/.claude/skills/blogburst` | Autonomous social media manager for Twitter/Bluesky/Telegram/Discord — writes posts, replies, learns what works. Replaces a $500-1,500/mo freelance SMM for $29-99/mo. Public endpoints demo content before signup. |
 | [Gear Foundation Skills](https://github.com/gear-foundation/vara-skills) | [Repo](https://github.com/gear-foundation/vara-skills) | 21 skills teaching AI coding agents to build and ship Rust smart contracts on Vara Network with Gear/Sails. Covers planning, implementation, testing, frontend, indexing, on-chain deployment, and safe program evolution. MIT. |
 | [Superpower Builder](https://github.com/redhuntlabs/superpower-builder) | `/plugin marketplace add redhuntlabs/superpower-builder` then `/plugin install superpower-builder@superpower-builder` | Interview-driven meta-builder that turns recurring tasks into reusable `SKILL.md` files. Routes by workflow/discipline/content/subagent kind, then pressure-tests baseline-without-skill vs. with-skill before saving. MIT, no telemetry. |
+| [handoff](https://github.com/dazuiba/handoff) | `uv tool install handoff-cli && handoff init` | Cross-agent dispatcher: delegate tasks to DeepSeek V4, Codex, or Opus from inside Claude Code |
 
 ### Installing Skills
 


### PR DESCRIPTION
## What is handoff?

[handoff](https://github.com/dazuiba/handoff) is a skill/subagent (backed by handoff-cli) that lets you delegate tasks to DeepSeek V4, Codex, or Claude Opus right inside your Claude Code / Codex session — without switching tools or losing context.

- Runs the delegated task in the background; your session never blocks
- Result comes back automatically when the task finishes
- Supports parallel tasks and resuming past sessions

## Why it belongs here

handoff is a Claude Code skill for cross-agent task delegation.

## Links

- GitHub: https://github.com/dazuiba/handoff
- Install: `uv tool install handoff-cli && handoff init`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added information about the handoff tool to the README, including GitHub link and installation instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->