### PR TITLE
Add cc-powerpack to Hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Over 176 production-ready plugins that extend Claude Code with domain-specific c
 
 | Plugin | Description |
 |--------|-------------|
+| [cc-powerpack](https://github.com/Ludoonus/cc-powerpack) | Three PreToolUse safety hooks: pre-push secret scanning (gitleaks + regex fallback + forbidden-file check), dangerous-command gate (rm -rf on unsafe paths, force-push to protected branches, curl pipe sh, chmod 777, dd to devices), and git worktree protection. MIT, 100% local, 18 functional tests. Install: `/plugin marketplace add Ludoonus/cc-powerpack` |
 | [agento-patronum](https://github.com/emaarco/agento-patronum) | Protects sensitive files, credentials, and shell commands from unintended AI access via Claude Code hooks. Unlike settings.json deny rules, hooks are an enforcement layer you own and can verify. Ships with defaults for .env files, SSH keys, AWS credentials, and kubeconfig. |
 | [skills-janitor](https://github.com/khendzel/skills-janitor) | Audit, deduplicate, check, fix, and track usage of your Claude Code skills. 9 slash commands, zero dependencies |
 | [great_cto](https://github.com/avelikiy/great_cto) | Full SDLC pipeline plugin with 7 agents (tech-lead, senior-dev, qa-engineer, security-officer, devops, l3-support, project-auditor), 12-angle code review, 10 project archetypes, 13 compliance frameworks (SOC2/HIPAA/PCI-DSS/GDPR/ISO 27001), two-gate approval flow. Opus 4.7 advisor escalation, file-based, MIT |


### PR DESCRIPTION
Adds [cc-powerpack](https://github.com/Ludoonus/cc-powerpack) to the Hooks table — three PreToolUse safety hooks (pre-push secret scanning, dangerous-command gate, worktree protection). MIT, runs fully locally, 18 functional tests, one-command marketplace install. Follows the existing table format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added cc-powerpack plugin entry to the Plugins table, including features, license information, test count, and installation instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->