### PR TITLE
Add Evidentia — medical citation verification & evidence appraisal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Claude Code Toolkit
 
-**The most comprehensive toolkit for Claude Code -- 135 agents, 35 curated skills (+400,000 via [SkillKit](https://agenstskills.com)), 42 commands, 176+ plugins, 20 hooks, 15 rules, 7 templates, 15 MCP configs, 26 companion apps, 53 ecosystem entries, and more.**
+**The most comprehensive toolkit for Claude Code -- 135 agents, 35 curated skills (+400,000 via [SkillKit](https://agenstskills.com)), 42 commands, 176+ plugins, 20 hooks, 15 rules, 7 templates, 15 MCP configs, 26 companion apps, 54 ecosystem entries, and more.**
 
 <p align="center">
   <a href="https://trendshift.io/repositories/21839" target="_blank"><img src="https://trendshift.io/api/badge/repositories/21839" alt="rohitg00%2Fawesome-claude-code-toolkit | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
@@ -1162,6 +1162,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [voidly-mcp-server](https://github.com/voidly-ai/mcp-server) | new | 116 tools for Claude Code covering censorship intelligence (19.6M OONI measurements, 126 countries), E2E encrypted agent-to-agent messaging, and agent payments. Install: `claude mcp add voidly -- npx -y @voidly/mcp-server` |
 | [systemprompt-template](https://github.com/systempromptio/systemprompt-template) | -- | Governance infrastructure for Claude Code. Single compiled Rust binary that authenticates, authorises, rate-limits, logs, and attributes costs for every AI interaction before it reaches a tool or database. Self-hosted, air-gap capable, MCP + A2A compatible. BSL-1.1 |
 | [llm-prices](https://github.com/benbencodes/llm-prices) | new | CLI + Python library + MCP server to look up and compare LLM API costs across 167 models from 23 providers (OpenAI, Anthropic, Google, xAI, DeepSeek, Groq, and more). Ask Claude "what's the cheapest model for 10k input + 2k output?" before making API calls. Zero deps, no API key. `pipx install git+https://github.com/benbencodes/llm-prices` |
+| [Evidentia](https://github.com/kgraph57/evidentia) | new | Catch AI-fabricated medical citations before you publish. Verifies DOIs/PMIDs/NCT/arXiv IDs against CrossRef, PubMed, and OpenAlex with 4-tier classification (verified / bibliographic mismatch / hallucination / content-review-needed) + a 15-criteria evidence-appraisal skill. CLI + MCP server + Claude Code plugin. No API key, zero runtime deps, MIT. Built by a pediatrician. `npx evidentia check file.md` |
 
 ---
 


### PR DESCRIPTION
Adds [Evidentia](https://github.com/kgraph57/evidentia) to the Ecosystem table. Evidentia catches AI-fabricated medical citations before publication: it extracts DOIs/PMIDs/NCT/arXiv IDs and resolves each against CrossRef, PubMed, and OpenAlex (no API key) with a 4-tier classification that distinguishes "real paper, wrong DOI" from "paper does not exist", plus a 15-criteria evidence-appraisal skill. It ships as a CLI (`npx evidentia check file.md`), MCP server, and Claude Code plugin — MIT licensed, zero runtime deps, deterministic engine (no LLM inside), 38 unit tests + 17-case live benchmark. Entry appended to the end of the Ecosystem table matching the surrounding row style, and the ecosystem entry count in the tagline bumped 53 → 54 per the contributing guideline to keep the README consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated ecosystem documentation to reflect 54 available integrations. Added Evidentia, a new tool designed to detect fabricated medical citations and verify reference accuracy. Accessible as a plugin, CLI tool, and MCP server for seamless integration with existing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->