### PR TITLE
Add Hookstack to Related Awesome Lists — community catalogue for Claude Code hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1206,6 +1206,7 @@ Tutorials, guides, and deep-dives on Claude Code.
 | [awesome-claude-design](https://github.com/rohitg00/awesome-claude-design) | ![Stars](https://img.shields.io/github/stars/rohitg00/awesome-claude-design?style=flat-square&label=) | DESIGN.md files grouped by aesthetic family (editorial, terminal, warm, data-dense, cinematic, playful, glass, brutalist, indie) + remix recipes + prompt packs for Claude Design (Anthropic Labs) |
 | [ai-skill](https://github.com/anomalyco/ai-skill) | - | AI skill discovery and management system - helps users find, evaluate, install and manage agent skills, tools, plugins and extensions |
 | [Awesome AI Startups](https://github.com/nowork-studio/awesome-ai-startups) | new | Curated directory of ~440 indie-built AI products (bootstrapped, pre-seed, angel-funded) across 18 categories — AI agents, coding tools, marketing, audio/voice, image/design, video, and more |
+| [Hookstack](https://github.com/steve-magne/hookstack) | ![Stars](https://img.shields.io/github/stars/steve-magne/hookstack?style=flat-square&label=) | Community catalogue of 90 production-ready Claude Code hooks covering 25 lifecycle events. Browse at hookstack.app, install with `npx hookstack-cli@latest install`. MIT. |
 
 ## Contributing
 


### PR DESCRIPTION
## What

Adds Hookstack (https://github.com/steve-magne/hookstack) to the Related Awesome Lists section.

## Why

Hookstack is a community catalogue of 90 production-tested Claude Code hooks covering 25 lifecycle events (PreToolUse, PostToolUse, SessionStart, Stop, and 21 others). Each hook ships as a plain .mjs with a Vitest unit test — no SDK, no external deps. The CLI (`npx hookstack-cli@latest install`) patches `.claude/hooks/` and `settings.json` directly. MIT licensed, actively maintained.

It fits the "related awesome lists" framing: a focused domain (hooks) that complements this toolkit's broader scope.

## Checklist

- [x] README table updated
- [x] No new scripts added (catalogue link, not an embedded script)
- [x] Verified no duplicate entry exists

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "Hookstack" to the Related Awesome Lists section, including GitHub repository link, star badge, project description, and installation command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->