### PR TITLE
Add TweetClaw plugin listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,8 +270,8 @@ Over 176 production-ready plugins that extend Claude Code with domain-specific c
 | [test-kitchen](https://github.com/2389-research/test-kitchen) | Parallel implementation exploration using competing subagents, with structured comparison and winner selection |
 | [test-results-analyzer](plugins/test-results-analyzer/) | Analyze test failures, identify patterns, and suggest targeted fixes |
 | [test-writer](plugins/test-writer/) | Generate comprehensive unit and integration tests with full coverage |
-| [TweetClaw](https://github.com/Xquik-dev/tweetclaw) | OpenClaw plugin for X/Twitter automation: search tweets and replies, post tweets and replies, export followers, manage media, monitor tweets, send direct messages, and run giveaway draws. Installs from npm as `@xquik/tweetclaw`; optional live calls use OpenClaw approval gates. |
 | [tool-evaluator](plugins/tool-evaluator/) | Evaluate and compare developer tools with structured scoring criteria |
+| [TweetClaw](https://github.com/Xquik-dev/tweetclaw) | OpenClaw plugin for X/Twitter automation: search tweets and replies, post tweets and replies, export followers, manage media, monitor tweets, send direct messages, and run giveaway draws. Installs from npm as `@xquik/tweetclaw`; optional live calls use OpenClaw approval gates. |
 | [type-migrator](plugins/type-migrator/) | Migrate JavaScript files to TypeScript with proper types |
 | [ui-designer](plugins/ui-designer/) | Implement UI designs from specs with pixel-perfect component generation |
 | [ultrathink](plugins/ultrathink/) | Deep analysis mode with extended reasoning for complex problems |

--- a/README.md
+++ b/README.md
@@ -270,6 +270,7 @@ Over 176 production-ready plugins that extend Claude Code with domain-specific c
 | [test-kitchen](https://github.com/2389-research/test-kitchen) | Parallel implementation exploration using competing subagents, with structured comparison and winner selection |
 | [test-results-analyzer](plugins/test-results-analyzer/) | Analyze test failures, identify patterns, and suggest targeted fixes |
 | [test-writer](plugins/test-writer/) | Generate comprehensive unit and integration tests with full coverage |
+| [TweetClaw](https://github.com/Xquik-dev/tweetclaw) | OpenClaw plugin for X/Twitter automation: search tweets and replies, post tweets and replies, export followers, manage media, monitor tweets, send direct messages, and run giveaway draws. Installs from npm as `@xquik/tweetclaw`; optional live calls use OpenClaw approval gates. |
 | [tool-evaluator](plugins/tool-evaluator/) | Evaluate and compare developer tools with structured scoring criteria |
 | [type-migrator](plugins/type-migrator/) | Migrate JavaScript files to TypeScript with proper types |
 | [ui-designer](plugins/ui-designer/) | Implement UI designs from specs with pixel-perfect component generation |


### PR DESCRIPTION
## Summary

- Add TweetClaw to the All Plugins catalog.
- Position it separately from the existing x-twitter-scraper skill because it is an OpenClaw code plugin installed from npm.
- Note concrete X/Twitter jobs and OpenClaw approval gates.

## Validation

- git diff --check
- Changed-link markdown-link-check for the new TweetClaw row
- Direct HTTP checks for TweetClaw GitHub, npm registry metadata, ClawHub, and the target repo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "TweetClaw" plugin entry to the README: includes a brief description, installation instructions, and reference/details for usage. This update clarifies how to add and configure the plugin and where to find related information within the documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->