### PR TITLE
Add agents-md-cookbook to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1162,6 +1162,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [voidly-mcp-server](https://github.com/voidly-ai/mcp-server) | new | 116 tools for Claude Code covering censorship intelligence (19.6M OONI measurements, 126 countries), E2E encrypted agent-to-agent messaging, and agent payments. Install: `claude mcp add voidly -- npx -y @voidly/mcp-server` |
 | [systemprompt-template](https://github.com/systempromptio/systemprompt-template) | -- | Governance infrastructure for Claude Code. Single compiled Rust binary that authenticates, authorises, rate-limits, logs, and attributes costs for every AI interaction before it reaches a tool or database. Self-hosted, air-gap capable, MCP + A2A compatible. BSL-1.1 |
 | [llm-prices](https://github.com/benbencodes/llm-prices) | new | CLI + Python library + MCP server to look up and compare LLM API costs across 167 models from 23 providers (OpenAI, Anthropic, Google, xAI, DeepSeek, Groq, and more). Ask Claude "what's the cheapest model for 10k input + 2k output?" before making API calls. Zero deps, no API key. `pipx install git+https://github.com/benbencodes/llm-prices` |
+| [agents-md-cookbook](https://github.com/Taiizor/agents-md-cookbook) | new | Tool-agnostic AGENTS.md authoring kit — 15 stack-specific templates, a tool compatibility matrix, a CLI + GitHub Action linter (`agents-md-lint`), and a migrator (`agents-md-migrate`) from .cursorrules/CLAUDE.md/Copilot/Windsurf/Cline/Aider. Zero-config, MIT. `npx agents-md-lint` |
 
 ---
 


### PR DESCRIPTION
## Summary
Adds agents-md-cookbook to the Ecosystem section — a tested, tool-agnostic kit for authoring AGENTS.md: 15 stack-specific templates, a tool compatibility matrix, an npm CLI + GitHub Action linter (agents-md-lint), and a migrator (agents-md-migrate) that converts .cursorrules / CLAUDE.md / Copilot / Windsurf / Cline / Aider into AGENTS.md.

## Why it fits
The Ecosystem section already lists AGENTS.md authoring/config peers (faf-cli, caliber, LynxPrompt, cc-agents-md, SpecLock). `npx agents-md-lint` validates and scores an AGENTS.md; `npx agents-md-migrate` converts existing rule files.

License: MIT. v1.0.0 on npm and the GitHub Marketplace. Appended as the last Ecosystem row (newest-at-bottom), Stars marked `new` per the section convention for brand-new tools. Per CONTRIBUTING, this only updates the README table and adds no generated attribution footers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added `agents-md-cookbook` to the README's Ecosystem list, a toolkit for AGENTS.md authoring that includes starter templates, a tool compatibility matrix, a GitHub Action linter for validation, and a migration utility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->