### PR TITLE
Add ship-gate (pre-push quality gate plugin)

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ Over 176 production-ready plugins that extend Claude Code with domain-specific c
 | [screen-reader-tester](plugins/screen-reader-tester/) | Screen reader compatibility testing and ARIA fixes |
 | [security-guidance](plugins/security-guidance/) | Security best practices advisor with vulnerability detection and fixes |
 | [seed-generator](plugins/seed-generator/) | Database seeding script generation with realistic data |
+| [ship-gate](https://github.com/aksheyw/claude-code-ship-gate) | A pre-push quality gate: a PreToolUse hook that blocks pushes to your protected branch until tests, code review, security, and a secret scan pass, so the usual "git push --no-verify" escape does not work. Hardened by a 14-lens review and 3 red-team passes. Install: /plugin marketplace add aksheyw/claude-code-ship-gate |
 | [sitemd](https://github.com/sitemd-cc/sitemd) | Build websites from Markdown via MCP. 22 tools for creating pages, generating content, configuring settings, running SEO audits, and deploying static sites to Cloudflare Pages |
 | [simmer](https://github.com/2389-research/simmer) | Iterative artifact refinement using judge subagents that score against user-defined criteria across multiple rounds |
 | [slack-notifier](plugins/slack-notifier/) | Slack integration for deployment and build notifications |


### PR DESCRIPTION
Adds [ship-gate](https://github.com/aksheyw/claude-code-ship-gate) to the **All Plugins** table, placed alphabetically.

A Claude Code plugin: a PreToolUse hook that blocks `git push` to your protected branch until tests, code review, security, and a secret scan pass. The hook runs above git, so a `git push --no-verify` cannot skip it. MIT, dependency-free (bash + jq + awk), 265-test suite, hardened by a 14-lens review and 3 red-team passes.

Install: `/plugin marketplace add aksheyw/claude-code-ship-gate`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "ship-gate" plugin to the plugins documentation list, including repository link and description of the pre-push quality gate functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->