### PR TITLE
Add superhighway-mcp: live web search MCP server for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,6 +320,8 @@ Over 176 production-ready plugins that extend Claude Code with domain-specific c
 | [axme-code](https://github.com/AxmeAI/axme-code) | Persistent project memory across sessions, architectural decisions with enforce levels, and pre-execution safety hooks that block dangerous commands at the harness level (not via prompts). Local-only storage, multi-repo workspace support, automatic knowledge extraction via background auditor. 100% on ToolEmu safety, 89% on LongMemEval at ~10x fewer tokens than competitors. |
 | [logic-lens](https://github.com/hyhmrright/logic-lens) | Logic-first code review plugin for Claude Code — detects behavioral bugs via semi-formal execution tracing. Finds logic errors linters and type checkers miss. Structured findings: Premises → Trace → Divergence → Remedy with L1–L6 risk codes. Six skills: logic-review, logic-explain, logic-diff, logic-locate, logic-health, logic-fix-all. |
 
+| [superhighway-mcp](https://github.com/patwalls/superhighway-mcp) | Live web search, news, images, scrape, and research for Claude Code — five MCP tools; agents pay per call in USDC via x402 (no signup) or free API key. `npx -y superhighway-mcp` |
+
 ### Installing a Plugin
 
 ```bash


### PR DESCRIPTION
## What

Adds [superhighway-mcp](https://github.com/patwalls/superhighway-mcp) to the All Plugins section — a live web search MCP server (search, news, images, scrape, research) that Claude Code agents can call directly.

Two usage modes:
- **x402 pay-per-call** — agents pay \$0.001/call in USDC on Base autonomously (no API key, no signup)
- **Free API key** — 1,000 free calls/month via `/account/signup`

Install one-liner:
```
npx -y superhighway-mcp
```

Fits alongside existing search/data MCP entries like `claude-context` and `clirank-mcp-server`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README to include information about the `superhighway-mcp` plugin, making it available in the plugin list for user reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->