### PR TITLE
Add Clave to Companion Apps & GUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1058,6 +1058,7 @@ claude-code-toolkit/               850+ files
 | [cctally](https://github.com/omrikais/cctally) | new | Track Claude Code subscription usage as a weekly $-per-1% trend. Local web dashboard, terminal UI, forecasts, threshold alerts. Apache-2.0, zero telemetry. |
 | [claude-code-notifier](https://github.com/saiso/claude-code-notifier) | new | Native macOS notifier for Claude Code. Swift + UserNotifications, custom Heroicons-derived icon (SF Symbols–free), click-through to your IDE (VS Code, Cursor, Windsurf, JetBrains, iTerm2, Terminal) via bundle ID swap, per-event sound labels, hardened inputs (allowlists, length caps, control-character stripping). Universal binary (arm64 + x86_64), macOS 12+, MIT |
 | [ToutKit](https://github.com/toutkit/toutkit) | new | Desktop notebook for AI CLIs (Claude Code, Codex, Gemini). Pairs a sidebar of notes with a built-in terminal and an in-app webview that renders whatever the AI writes — each note is a self-contained folder with its own SQLite, key/value store, attached files, and scripts, so a note can grow from a static page into a sortable table, dashboard, or research tool. Local-first, AGPL-3.0 |
+| [Clave](https://github.com/codika-io/clave) | 25 | Native macOS app for running multiple coding-agent CLIs (Claude Code, Gemini CLI, Codex) in parallel. Split/grid layouts, per-project session groups, a built-in git panel with one-click AI commits, and local or remote (SSH/SFTP) file editing. Fully local, MIT |
 
 ---
 


### PR DESCRIPTION
Adds **Clave** to the *Companion Apps & GUIs* table.

- **Repo:** https://github.com/codika-io/clave
- Native macOS app for running multiple coding-agent CLIs (Claude Code, Gemini CLI, Codex) in parallel: split/grid layouts, per-project session groups, a built-in git panel with one-click AI commits, and local or remote (SSH/SFTP) file editing. Fully local, MIT.
- Latest release v1.56.1 (June 2026).

Single row, follows the existing `| Name | Stars | Description |` format. README table updated per CONTRIBUTING.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added information about Clave, a native macOS companion app for running multiple coding-agent CLIs in parallel with split/grid layouts, session grouping, and local/remote file editing capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->