### PR TITLE
Add OpenClacky to Ecosystem — open-source Claude Code alternative, 93.8% cache hit rate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1067,6 +1067,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 
 | Name | Stars | Description |
 |------|-------|-------------|
+| [OpenClacky](https://openclacky.com) | MIT | Open-source Claude Code alternative. **93.8% Prompt Cache hit rate** and **~0.8× API cost** via frozen 16-tool schema, dual cache markers, and Insert-then-Compress context management. BYOK: Claude, GPT-4, DeepSeek, Gemini, OpenRouter. [GitHub](https://github.com/clacky-ai/open-clacky) |
 | [claude-mem](https://github.com/thedotmack/claude-mem) | 35,900+ | Auto-captures everything Claude does, compresses with AI, injects context into future sessions. #1 trending GitHub Feb 2026 |
 | [wshobson/agents](https://github.com/wshobson/agents) | 31,300+ | 112 specialized agents, 16 orchestrators, 146 skills, 79 tools in 72 focused plugins |
 | [oh-my-claudecode](https://github.com/Yeachan-Heo/oh-my-claudecode) | 9,900+ | Teams-first multi-agent orchestration with 19 specialized agents and 28 skills |


### PR DESCRIPTION
## What's being added

[OpenClacky](https://openclacky.com) — added to the **Ecosystem** table as a notable open-source Claude Code alternative.

GitHub: https://github.com/clacky-ai/open-clacky

## Why it fits the Ecosystem section

The Ecosystem table covers notable projects across the Claude Code space. OpenClacky is an open-source alternative to Claude Code with a distinct technical achievement: **93.8% Prompt Cache hit rate** (7-day global average), which translates to **~0.8x the API cost** of Claude Code.

Mechanism:
- Frozen 16-tool schema keeps the system prompt cache intact across sessions
- Dual cache markers on both system block and tool definitions
- Insert-then-Compress context management preserves the cached prefix
- No tool-order churn

**BYOK**: Claude, GPT-4, DeepSeek, Gemini, OpenRouter
**License**: MIT
**Website**: https://openclacky.com

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added OpenClacky to the Ecosystem table with licensing details and features highlighting cache optimization and API cost efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->