### PR TITLE
Add operator-kit to Ecosystem section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1162,6 +1162,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [voidly-mcp-server](https://github.com/voidly-ai/mcp-server) | new | 116 tools for Claude Code covering censorship intelligence (19.6M OONI measurements, 126 countries), E2E encrypted agent-to-agent messaging, and agent payments. Install: `claude mcp add voidly -- npx -y @voidly/mcp-server` |
 | [systemprompt-template](https://github.com/systempromptio/systemprompt-template) | -- | Governance infrastructure for Claude Code. Single compiled Rust binary that authenticates, authorises, rate-limits, logs, and attributes costs for every AI interaction before it reaches a tool or database. Self-hosted, air-gap capable, MCP + A2A compatible. BSL-1.1 |
 | [llm-prices](https://github.com/benbencodes/llm-prices) | new | CLI + Python library + MCP server to look up and compare LLM API costs across 167 models from 23 providers (OpenAI, Anthropic, Google, xAI, DeepSeek, Groq, and more). Ask Claude "what's the cheapest model for 10k input + 2k output?" before making API calls. Zero deps, no API key. `pipx install git+https://github.com/benbencodes/llm-prices` |
+| [operator-kit](https://github.com/wrg32786/operator-kit) | new | Five-agent Claude Code starter kit -- Iris (design), Lyra (build), Echo (scout), Newton (research), Hypatia (critic) -- with a context-loading hook and single-command install. MIT |
 
 ---
 


### PR DESCRIPTION
## Summary

Adds [operator-kit](https://github.com/wrg32786/operator-kit) to the Ecosystem section table.

## Row added

```
| [operator-kit](https://github.com/wrg32786/operator-kit) | new | Five-agent Claude Code starter kit -- Iris (design), Lyra (build), Echo (scout), Newton (research), Hypatia (critic) -- with a context-loading hook and single-command install. MIT |
```

Matches the three-column format (`Name | Stars | Description`) used by all existing Ecosystem rows. Stars field uses `new` per the convention for recently-published projects.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added "operator-kit" entry to the ecosystem projects list—a five-agent Claude Code starter kit with integrated context-loading capabilities and simplified single-command installation, available under MIT license.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->