### PR TITLE
Add Agentage Memory (remote MCP server)

### DIFF
--- a/README.md
+++ b/README.md
@@ -921,7 +921,7 @@ cp templates/claude-md/standard.md CLAUDE.md
 
 ## MCP Configs
 
-Sixteen curated Model Context Protocol server configurations.
+Seventeen curated Model Context Protocol server configurations.
 
 | Config | File | Servers Included |
 |--------|------|-----------------|
@@ -941,6 +941,7 @@ Sixteen curated Model Context Protocol server configurations.
 | Finance | [`finance.json`](mcp-configs/finance.json) | Helium news/markets/options, Chart Library pattern intelligence, Fetch, Memory |
 | E-Commerce | [`ecommerce.json`](mcp-configs/ecommerce.json) | BuyWhere product search, price comparison, deal discovery across 1M+ products |
 | LLM Cost | [`llm-cost.json`](mcp-configs/llm-cost.json) | llm-prices: look up and compare API costs across 167 models from 23 providers before making calls |
+| Memory | [`memory.json`](mcp-configs/memory.json) | agentage Memory: one markdown memory shared across Claude, Cursor & ChatGPT via 6 memory__* tools, remote MCP (Streamable HTTP) + OAuth 2.1/PKCE/DCR |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -941,7 +941,7 @@ Seventeen curated Model Context Protocol server configurations.
 | Finance | [`finance.json`](mcp-configs/finance.json) | Helium news/markets/options, Chart Library pattern intelligence, Fetch, Memory |
 | E-Commerce | [`ecommerce.json`](mcp-configs/ecommerce.json) | BuyWhere product search, price comparison, deal discovery across 1M+ products |
 | LLM Cost | [`llm-cost.json`](mcp-configs/llm-cost.json) | llm-prices: look up and compare API costs across 167 models from 23 providers before making calls |
-| Memory | [`memory.json`](mcp-configs/memory.json) | agentage Memory: one markdown memory shared across Claude, Cursor & ChatGPT via 6 memory__* tools, remote MCP (Streamable HTTP) + OAuth 2.1/PKCE/DCR |
+| Memory | [`memory.json`](mcp-configs/memory.json) | Agentage Memory: one markdown memory shared across Claude, Cursor & ChatGPT via 6 memory__* tools, remote MCP (Streamable HTTP) + OAuth 2.1/PKCE/DCR |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Claude Code Toolkit
 
-**The most comprehensive toolkit for Claude Code -- 135 agents, 35 curated skills (+400,000 via [SkillKit](https://agenstskills.com)), 42 commands, 176+ plugins, 20 hooks, 15 rules, 7 templates, 15 MCP configs, 26 companion apps, 53 ecosystem entries, and more.**
+**The most comprehensive toolkit for Claude Code -- 135 agents, 35 curated skills (+400,000 via [SkillKit](https://agenstskills.com)), 42 commands, 176+ plugins, 20 hooks, 15 rules, 7 templates, 16 MCP configs, 26 companion apps, 53 ecosystem entries, and more.**
 
 <p align="center">
   <a href="https://trendshift.io/repositories/21839" target="_blank"><img src="https://trendshift.io/api/badge/repositories/21839" alt="rohitg00%2Fawesome-claude-code-toolkit | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>

--- a/mcp-configs/memory.json
+++ b/mcp-configs/memory.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "agentage-memory": {
       "url": "https://memory.agentage.io/mcp",
-      "description": "agentage Memory - one memory shared across every AI, owned by you. Remote MCP server (Streamable HTTP) for a markdown memory that Claude, Cursor, and ChatGPT read and write through 6 tools (memory__search, memory__read, memory__write, memory__edit, memory__list, memory__delete). OAuth 2.1 + PKCE + Dynamic Client Registration; no manual token. https://memory.agentage.io"
+      "description": "Agentage Memory - one memory shared across every AI, owned by you. Remote MCP server (Streamable HTTP) for a markdown memory that Claude, Cursor, and ChatGPT read and write through 6 tools (memory__search, memory__read, memory__write, memory__edit, memory__list, memory__delete). OAuth 2.1 + PKCE + Dynamic Client Registration; no manual token. https://memory.agentage.io"
     }
   }
 }

--- a/mcp-configs/memory.json
+++ b/mcp-configs/memory.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "agentage-memory": {
+      "url": "https://memory.agentage.io/mcp",
+      "description": "agentage Memory - one memory shared across every AI, owned by you. Remote MCP server (Streamable HTTP) for a markdown memory that Claude, Cursor, and ChatGPT read and write through 6 tools (memory__search, memory__read, memory__write, memory__edit, memory__list, memory__delete). OAuth 2.1 + PKCE + Dynamic Client Registration; no manual token. https://memory.agentage.io"
+    }
+  }
+}


### PR DESCRIPTION
Adds **Agentage Memory**, a remote MCP server (Streamable HTTP) that gives every AI tool one shared markdown memory you own.

- **Endpoint:** `https://memory.agentage.io/mcp`
- **Auth:** OAuth 2.1 + PKCE + Dynamic Client Registration (no API key)
- **Website:** https://agentage.io
- **Documentation:** https://agentage.io/blog/mcp-endpoint-is-live
- **Official MCP registry:** `io.agentage/memory`

**Tools (6):** `memory__search`, `memory__read`, `memory__write`, `memory__edit`, `memory__list`, `memory__delete` — one markdown memory that Claude, Cursor, and ChatGPT all read and write, mirrored locally as plain `.md` you can export anytime.

Happy to adjust placement/format to match this list's conventions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the MCP Configs documentation to reflect **17** curated server configurations (up from 16).

* **New Features**
  * Added a new **Memory** server configuration to the available options, enabling shared markdown memory capabilities via the Memory MCP server.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->