### PR TITLE
Add delta-engage skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -675,6 +675,8 @@ Thirty-five curated skill modules included in this repo, with access to **400,00
 | [BlogBurst](https://github.com/shensi8312/blogburst-claude-skill) | `git clone https://github.com/shensi8312/blogburst-claude-skill ~/.claude/skills/blogburst` | Autonomous social media manager for Twitter/Bluesky/Telegram/Discord — writes posts, replies, learns what works. Replaces a $500-1,500/mo freelance SMM for $29-99/mo. Public endpoints demo content before signup. |
 | [Gear Foundation Skills](https://github.com/gear-foundation/vara-skills) | [Repo](https://github.com/gear-foundation/vara-skills) | 21 skills teaching AI coding agents to build and ship Rust smart contracts on Vara Network with Gear/Sails. Covers planning, implementation, testing, frontend, indexing, on-chain deployment, and safe program evolution. MIT. |
 | [Superpower Builder](https://github.com/redhuntlabs/superpower-builder) | `/plugin marketplace add redhuntlabs/superpower-builder` then `/plugin install superpower-builder@superpower-builder` | Interview-driven meta-builder that turns recurring tasks into reusable `SKILL.md` files. Routes by workflow/discipline/content/subagent kind, then pressure-tests baseline-without-skill vs. with-skill before saving. MIT, no telemetry. |
+| [delta-engage](https://github.com/newan2001/delta-engage) | `git clone --depth 1 https://github.com/newan2001/delta-engage.git ~/.claude/skills/delta-engage && cd ~/.claude/skills/delta-engage && ./setup` | Finds demand-side engagement opportunities on Reddit & LinkedIn (buyers, not competitors), classifies intent (buyer/peer/KOL), drafts a comment per post in your voice, and delivers a twice-weekly digest. Cookieless, BYOK. |
+
 
 ### Installing Skills
 


### PR DESCRIPTION
Adds **delta-engage** — an open-source (MIT) Claude Code skill: https://github.com/newan2001/delta-engage

Finds demand-side engagement opportunities on Reddit & LinkedIn (the people voicing the pain you solve, not competitors), classifies intent (buyer/peer/KOL), drafts a comment per post in your voice, and delivers a twice-weekly digest. Cookieless LinkedIn discovery, BYO Apify token, you post manually. Added under Community Skills.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for the "delta-engage" skill to the Community Skills list, including setup instructions and information about its Reddit and LinkedIn engagement and digest capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->