### PR TITLE
Add t3d (DDD + TDD harness) to All Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Over 176 production-ready plugins that extend Claude Code with domain-specific c
 | [claude-context](https://github.com/zilliztech/claude-context) | Semantic code search MCP server by Zilliz (Milvus creators). Hybrid BM25 + dense vector search. ~40% token reduction. 5,600+ stars |
 | [claude-cost-optimizer](https://github.com/Sagargupta16/claude-cost-optimizer) | Installable cost-mode skill (30-60% cost savings, up to 70% in strict mode) + 10 guides, 10 templates, budget hooks. Install: `npx skills add Sagargupta16/claude-cost-optimizer` |
 | [fractal](https://github.com/rmolines/fractal) | Recursive project management for Claude Code. Decomposes goals into predicates, works the riskiest piece first, and re-evaluates as it learns |
+| [t3d](https://github.com/coolsocket/t3d) | DDD + TDD harness for Python projects -- 5 hooks deny external-framework imports in Domain layers, deny cross-context internal imports, and block Stop when Domain was edited but tests are red. Ships 4 skills (init, new-context, grill-me, sinkin) and project templates with a 4-layer bounded-context skeleton. Install: `/plugin marketplace add coolsocket/t3d` |
 | [a11y-audit](plugins/a11y-audit/) | Full accessibility audit with WCAG compliance checking |
 | [accessibility-checker](plugins/accessibility-checker/) | Scan for accessibility issues and fix ARIA attributes in web applications |
 | [adr-writer](plugins/adr-writer/) | Architecture Decision Records authoring and management |


### PR DESCRIPTION
Adds [t3d](https://github.com/coolsocket/t3d) to the All Plugins table.

## What

A small Claude Code plugin (5 hooks, 4 skills, project templates) that enforces DDD bounded-context discipline and TDD red-green at edit time.

## Why useful in this list

- Different from existing audit plugins: t3d enforces architectural invariants AT EDIT TIME (PreToolUse), not after the fact.
- Different from existing TDD tooling: paired with cross-context import enforcement so Claude can't take shortcuts that compile but break the boundary.
- Self-contained: 5 shell + jq hooks + 4 skills, no runtime deps beyond what Python users already have.

## Verification

```
/plugin marketplace add coolsocket/t3d
/plugin install t3d

# In any project:
/t3d-init                              # copies CLAUDE.md + 4-layer template
# then try: edit contexts/foo/domain/x.py with 'import fastapi'
# → PreToolUse hook returns permissionDecision=deny with a structured reason
```

Manifest validates with `claude plugin validate .`. CI green: https://github.com/coolsocket/t3d/actions

## Diff

One row added between `fractal` and the in-tree `a11y-audit` (keeping the external-vs-in-tree grouping).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added information about the `t3d` plugin, including its description and installation command, to the plugins reference guide.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->