### PR TITLE
Add sipcode to Hooks > Related SDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -838,6 +838,7 @@ If you prefer a typed, npm-installable foundation for writing hooks rather than 
 
 - [claude-code-hooks](https://github.com/Payshak/claude-code-hooks) — TypeScript SDK with `defineHook()`, typed event payloads for all 5 hook events, response builders, and unit-testable `.handle()` method. Zero dependencies.
 - [EchoCoding](https://github.com/launsion-boop/EchoCoding) — Audio layer for coding agents with hook-triggered SFX, ambient soundscape, and optional cloud TTS/ASR voice interaction. Works with Claude Code hooks and also supports Cursor/Windsurf, Codex CLI, and Gemini CLI.
+- [sipcode](https://github.com/Anuj7411/sipcode) — A PreToolUse hook and CLI that caps verbose tool output and dedups same-session file re-reads to keep Claude Code's context clean. Ships 15 MCP tools and a reproducible benchmark; about 62% median tool-output savings. MIT, zero network calls in normal use.
 
 ### Installing Hooks
 


### PR DESCRIPTION
Adding **sipcode** to the Hooks > Related SDKs subsection, alongside the other npm-installable hook tools.

sipcode is an open-source (MIT) PreToolUse hook and CLI for Claude Code that caps verbose tool output and deduplicates same-session file re-reads to keep the context clean. It ships 15 MCP tools that expose context-hygiene stats during a session, plus a reproducible benchmark (~62% median tool-output savings). Zero network calls in normal use, enforced by a build-failing privacy test.

- Repo: https://github.com/Anuj7411/sipcode
- npm: https://www.npmjs.com/package/sipcode

Single-line addition, matches the existing format in that subsection.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added sipcode to the list of related SDKs in README, documenting its functionality for managing tool output verbosity and deduplicating file re-reads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->