### PR TITLE
Add automatic-episodic-memory plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -36,6 +36,12 @@
       "version": "1.0.0"
     },
     {
+      "name": "automatic-episodic-memory",
+      "source": "https://github.com/automattf/automatic-episodic-memory",
+      "description": "Episodic memory with automatic recall for Claude Code: captures work across context compactions and surfaces relevant past episodes automatically on prompts, tool calls, and turn end, with no manual logging or lookup.",
+      "version": "1.0.0"
+    },
+    {
       "name": "ai-prompt-lab",
       "source": "plugins/ai-prompt-lab",
       "description": "Improve and test AI prompts for better Claude Code interactions",

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Over 176 production-ready plugins that extend Claude Code with domain-specific c
 | [api-benchmarker](plugins/api-benchmarker/) | API endpoint benchmarking and performance reporting |
 | [api-reference](plugins/api-reference/) | API reference documentation generation from source code |
 | [api-tester](plugins/api-tester/) | Test API endpoints and run load tests against services |
+| [automatic-episodic-memory](https://github.com/automattf/automatic-episodic-memory) | Episodic memory with automatic recall for Claude Code: captures work across context compactions and surfaces relevant past episodes automatically on prompts, tool calls, and turn end, with no manual logging or lookup. Install: `/plugin marketplace add automattf/claude-plugins` then `/plugin install automatic-episodic-memory@automattf-plugins` |
 | [aws-helper](plugins/aws-helper/) | AWS service configuration and deployment automation |
 | [azure-helper](plugins/azure-helper/) | Azure service configuration and deployment automation |
 | [backend-architect](plugins/backend-architect/) | Backend service architecture design with endpoint scaffolding |


### PR DESCRIPTION
Adds automatic-episodic-memory.

Episodic memory with automatic recall for Claude Code: it captures work across context compactions and surfaces relevant past episodes automatically on prompts, tool calls, and turn end, with no manual logging or lookup.

How it differs from other memory plugins: most memory and notes plugins are recall-on-demand or manual-capture, where the agent has to remember to log a memory and to query for it. This one automates both ends. Capture runs automatically when the context window compacts, and recall is hook-driven, surfacing the relevant past episode on its own before the agent reasons. That hands-free automatic recall is the distinguishing feature, so this is not a duplicate of existing memory entries.

Repo: https://github.com/automattf/automatic-episodic-memory
Install: `/plugin marketplace add automattf/claude-plugins` then `/plugin install automatic-episodic-memory@automattf-plugins`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new plugin entry to the marketplace listing.
  * Updated the plugins catalog to include **automatic-episodic-memory**.
  * Added README details and installation commands for the new plugin.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->