### PR TITLE
Add lore plugin (learnings capture/recall for Claude Code & Codex)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Over 176 production-ready plugins that extend Claude Code with domain-specific c
 
 | Plugin | Description |
 |--------|-------------|
+| [lore](https://github.com/aoc81/lore) | Self-maintaining learnings system for Claude Code & Codex. A `UserPromptSubmit` hook auto-recalls relevant past learnings into context and a `PreToolUse` hook surfaces file-specific gotchas at edit time; a `Stop` hook nudges capture of only non-obvious, reusable facts. Freshness linter flags entries whose referenced code changed, and a blocking pre-push secret scan guards the store. Plain-markdown store committed in your repo. Stdlib Python, zero deps, no network. MIT |
 | [agento-patronum](https://github.com/emaarco/agento-patronum) | Protects sensitive files, credentials, and shell commands from unintended AI access via Claude Code hooks. Unlike settings.json deny rules, hooks are an enforcement layer you own and can verify. Ships with defaults for .env files, SSH keys, AWS credentials, and kubeconfig. |
 | [skills-janitor](https://github.com/khendzel/skills-janitor) | Audit, deduplicate, check, fix, and track usage of your Claude Code skills. 9 slash commands, zero dependencies |
 | [great_cto](https://github.com/avelikiy/great_cto) | Full SDLC pipeline plugin with 7 agents (tech-lead, senior-dev, qa-engineer, security-officer, devops, l3-support, project-auditor), 12-angle code review, 10 project archetypes, 13 compliance frameworks (SOC2/HIPAA/PCI-DSS/GDPR/ISO 27001), two-gate approval flow. Opus 4.7 advisor escalation, file-based, MIT |


### PR DESCRIPTION
Adds **lore** to the **All Plugins** table.

- Repo: https://github.com/aoc81/lore
- License: MIT

lore is a self-maintaining learnings system for Claude Code & Codex. A `UserPromptSubmit` hook auto-recalls relevant past learnings into context, a `PreToolUse` hook surfaces file-specific gotchas at edit time, and a `Stop` hook nudges capture of only non-obvious, reusable facts. It ships a freshness linter (flags entries whose referenced code changed since they were last verified) and a blocking pre-push secret scan over the store. The store is plain markdown committed in your repo so a whole team shares it. Stdlib Python, zero deps, no network calls — works on macOS/Linux/Windows.

Follows the existing `| [name](url) | description |` row format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the plugins overview to include the new `lore` entry with its key capabilities and notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->