### PR TITLE
Add skillreaper — transcript-based context pruning CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1162,6 +1162,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [voidly-mcp-server](https://github.com/voidly-ai/mcp-server) | new | 116 tools for Claude Code covering censorship intelligence (19.6M OONI measurements, 126 countries), E2E encrypted agent-to-agent messaging, and agent payments. Install: `claude mcp add voidly -- npx -y @voidly/mcp-server` |
 | [systemprompt-template](https://github.com/systempromptio/systemprompt-template) | -- | Governance infrastructure for Claude Code. Single compiled Rust binary that authenticates, authorises, rate-limits, logs, and attributes costs for every AI interaction before it reaches a tool or database. Self-hosted, air-gap capable, MCP + A2A compatible. BSL-1.1 |
 | [llm-prices](https://github.com/benbencodes/llm-prices) | new | CLI + Python library + MCP server to look up and compare LLM API costs across 167 models from 23 providers (OpenAI, Anthropic, Google, xAI, DeepSeek, Groq, and more). Ask Claude "what's the cheapest model for 10k input + 2k output?" before making API calls. Zero deps, no API key. `pipx install git+https://github.com/benbencodes/llm-prices` |
+| [skillreaper](https://github.com/thousandflowers/skillreaper) | 31 | Reads real session transcripts (`~/.claude/projects/*.jsonl` and equivalents) to find skills, MCP servers, and agents that were loaded but never fired, then safely quarantines them. Supports Claude Code, Codex, Hermes, OpenCode, Cursor, and OpenClaw. Zero telemetry, single static Go binary, Homebrew + npm. MIT |
 
 ---
 


### PR DESCRIPTION
Adds [**skillreaper**](https://github.com/thousandflowers/skillreaper) as a new row in the **Ecosystem** table.

**What it does:** reads real session transcripts (`~/.claude/projects/*.jsonl` and equivalents) to find skills, MCP servers, and agents that were loaded into context but never fired, then safely quarantines them to cut context bloat.

**Why it fits the Ecosystem table:** it sits right next to the transcript-analysis tools already listed (e.g. `getburnd`, `claude-token-lens`) — same JSONL-evidence approach, but for pruning unused skills/MCP/agents rather than token accounting. Supports Claude Code, Codex CLI, Hermes, OpenCode, Cursor, and OpenClaw. Zero telemetry, single static Go binary, Homebrew + npm, MIT.

Only README.md changed (one row added).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new Ecosystem listing for a utility that analyzes local Claude Code session transcripts to identify unused skills, MCP servers, and agents, then quarantines them safely.
  * Included compatibility notes for multiple Claude Code-supported environments, plus installation and distribution details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->