### PR TITLE
Add Skill Hub - Multi-platform AI Agent Skills navigator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1206,6 +1206,7 @@ Tutorials, guides, and deep-dives on Claude Code.
 | [awesome-claude-design](https://github.com/rohitg00/awesome-claude-design) | ![Stars](https://img.shields.io/github/stars/rohitg00/awesome-claude-design?style=flat-square&label=) | DESIGN.md files grouped by aesthetic family (editorial, terminal, warm, data-dense, cinematic, playful, glass, brutalist, indie) + remix recipes + prompt packs for Claude Design (Anthropic Labs) |
 | [ai-skill](https://github.com/anomalyco/ai-skill) | - | AI skill discovery and management system - helps users find, evaluate, install and manage agent skills, tools, plugins and extensions |
 | [Awesome AI Startups](https://github.com/nowork-studio/awesome-ai-startups) | new | Curated directory of ~440 indie-built AI products (bootstrapped, pre-seed, angel-funded) across 18 categories — AI agents, coding tools, marketing, audio/voice, image/design, video, and more |
+| [Skill Hub](https://skill.442595.xyz/) | 577+ skills | Multi-platform AI Agent Skills navigator — browse by function category across Claude Code, Codex, Cursor, OpenCode, OpenClaw, Hermes, Copilot, Gemini. [GitHub](https://github.com/rdone4425/skill) |
 
 ## Contributing
 


### PR DESCRIPTION
## Suggestion: Add Skill Hub

**Project:** [Skill Hub](https://skill.442595.xyz/)  
**GitHub:** [rdone4425/skill](https://github.com/rdone4425/skill)
**Current Stats:** 577+ skills | 12+ platforms | 10 categories

### What is Skill Hub?
Skill Hub is an open-source navigation site for AI Agent Skills. It aggregates skills across multiple AI coding platforms:
- Claude Code, Codex, Cursor, OpenCode, OpenClaw, Hermes, Copilot, Gemini, MCP, and more
- 577+ curated skills organized by **function category** (Dev Tools, Design UI, Automation, Security, Testing, Data AI, Docs, Backend API, DevOps)
- Platform compatibility filtering
- Fully open source with automated data refresh

### Why add to this list?
Skill Hub complements `awesome-claude-code-toolkit` by providing cross-platform skill discovery — users can find Claude Code skills alongside skills from Codex, Cursor, OpenCode, and 9+ other platforms, all organized by function category.

### Location
Added to the `## Related Awesome Lists` table, following the same format as existing entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new entry to the related resources list for Skill Hub, including its website, repository, and a brief description of available AI agent skills across supported ecosystems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->