### PR TITLE
Add safedeps to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1162,6 +1162,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [voidly-mcp-server](https://github.com/voidly-ai/mcp-server) | new | 116 tools for Claude Code covering censorship intelligence (19.6M OONI measurements, 126 countries), E2E encrypted agent-to-agent messaging, and agent payments. Install: `claude mcp add voidly -- npx -y @voidly/mcp-server` |
 | [systemprompt-template](https://github.com/systempromptio/systemprompt-template) | -- | Governance infrastructure for Claude Code. Single compiled Rust binary that authenticates, authorises, rate-limits, logs, and attributes costs for every AI interaction before it reaches a tool or database. Self-hosted, air-gap capable, MCP + A2A compatible. BSL-1.1 |
 | [llm-prices](https://github.com/benbencodes/llm-prices) | new | CLI + Python library + MCP server to look up and compare LLM API costs across 167 models from 23 providers (OpenAI, Anthropic, Google, xAI, DeepSeek, Groq, and more). Ask Claude "what's the cheapest model for 10k input + 2k output?" before making API calls. Zero deps, no API key. `pipx install git+https://github.com/benbencodes/llm-prices` |
+| [safedeps](https://github.com/Jeneidi/safedeps) | new | Grounds dependency choices in live OSV.dev/CVE data so Claude stops suggesting known-vulnerable package versions. Skill + `PreToolUse` hook, stdlib-only, no API key. |
 
 ---
 


### PR DESCRIPTION
Adds [safedeps](https://github.com/Jeneidi/safedeps) to the Ecosystem table.

## What it is

A Claude Code skill + `PreToolUse` hook that checks dependency names/versions against live OSV.dev vulnerability data before they're added to a project, so the agent stops recommending package versions with known CVEs from stale training-data memory.

## Why it fits here

- Targets a real, recurring failure mode of coding agents (suggesting known-vulnerable dependencies) rather than a hypothetical one.
- Stdlib-only, no new dependencies, no API key required.
- Built around the existing skill + `PreToolUse` hook mechanism already used by other entries in this list.

Disclosure: I'm the author/maintainer of safedeps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Ecosystem table with a new “safedeps” entry.
  * Added a brief description highlighting live OSV.dev/CVE-backed dependency guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->