### PR TITLE
Add BankBridge to Finance MCP config — read-only bank access for AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -938,7 +938,7 @@ Sixteen curated Model Context Protocol server configurations.
 | Design | [`design.json`](mcp-configs/design.json) | Figma design context, Blender 3D automation |
 | Workflow Automation | [`workflow-automation.json`](mcp-configs/workflow-automation.json) | n8n workflow builder, Pipedream integration |
 | Mobile | [`mobile.json`](mcp-configs/mobile.json) | Android ADB automation, Xcode build tools |
-| Finance | [`finance.json`](mcp-configs/finance.json) | Helium news/markets/options, Chart Library pattern intelligence, Fetch, Memory |
+| Finance | [`finance.json`](mcp-configs/finance.json) | Helium news/markets/options, BankBridge read-only bank accounts/transactions/investments, Chart Library pattern intelligence, Fetch, Memory |
 | E-Commerce | [`ecommerce.json`](mcp-configs/ecommerce.json) | BuyWhere product search, price comparison, deal discovery across 1M+ products |
 | LLM Cost | [`llm-cost.json`](mcp-configs/llm-cost.json) | llm-prices: look up and compare API costs across 167 models from 23 providers before making calls |
 

--- a/mcp-configs/finance.json
+++ b/mcp-configs/finance.json
@@ -4,6 +4,10 @@
       "url": "https://heliumtrades.com/mcp",
       "description": "Real-time news with bias scoring across 5,000+ sources, live stock/ETF/crypto data with AI bull/bear cases and price forecasts, ML options pricing with probability ITM, balanced news synthesis, and meme search. 9 tools, free tier (50 queries), no API key needed."
     },
+    "bankbridge": {
+      "url": "https://bankbridge.money/api/mcp",
+      "description": "Read-only access to your real bank accounts, transactions, and investment holdings. 12 tools — balances, spending summaries, recurring charges, monthly cashflow, holdings, investment txns. Live-fetched on every call. OAuth 2.1 or Bearer API key (bbk_...). $5/mo per connected bank. Hosted at https://bankbridge.money."
+    },
     "chart-library": {
       "command": "python",
       "args": ["-m", "chartlibrary_mcp"],


### PR DESCRIPTION
Adds [BankBridge](https://bankbridge.money) to the Finance MCP config.

BankBridge is a hosted MCP server that gives Claude Code read-only access to real bank accounts, transactions, and investment holdings. 12 tools — balances, spending summaries, recurring charges, monthly cashflow, holdings, investment txns. Live-fetched on every call. OAuth 2.1 / Bearer API key. \$5/mo per connected bank.

Press kit: https://bankbridge.money/press

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Finance MCP server configuration entry for Bankbridge, including its connection details and usage information.
  * This adds another option for read-only bank and account access with live data fetching and OAuth/Bearer authentication.

* **Documentation**
  * Updated the MCP Configs table in the README with a minor formatting change for the Finance entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->