### PR TITLE
Add Vexilo to Resources — visual field guide to Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1189,6 +1189,7 @@ Tutorials, guides, and deep-dives on Claude Code.
 | [Computer Use from CLI](https://code.claude.com/docs/en/computer-use) | Docs | Let Claude control your desktop — open apps, click, type, screenshot. macOS, Pro/Max, v2.1.85+. Per-app approval, tiered access, Esc abort |
 | [Dispatch & Remote Control](https://claude.com/blog/dispatch-and-computer-use) | Blog | Run Claude Code from phone/web, schedule recurring tasks, remote session control |
 | [Claude Code Cheat Sheet](https://cc.storyfox.cz/) | Reference | One-page printable reference, auto-updated daily, 4 languages |
+| [Vexilo · A field guide to Claude Code](https://vexilo.app/?lang=en) | Field Guide | Visual interactive index — 31 agents · 99 commands · 123 skills · 13 rules, organized around the 5-step workflow (Research → Plan → Test-first → Security → Commit). One-click "Teach Claude this handbook" feeds the whole guide into a local Claude session in 30 seconds. Runs in browser, no install ([companion repo](https://github.com/lilhawk7077/claude-code-resources)) |
 | [Multi-Agent Orchestra](https://addyosmani.com/blog/code-agent-orchestra/) | Blog | Addy Osmani's survey of multi-agent coding patterns |
 
 ## Related Awesome Lists


### PR DESCRIPTION
## Adds Vexilo · A field guide to Claude Code to the Resources table

**Vexilo** ([vexilo.app/?lang=en](https://vexilo.app/?lang=en)) is a live, interactive, visual index of **31 agents · 99 commands · 123 skills · 13 rules**, organized around the 5-step workflow (Research → Plan → Test-first → Security → Commit). The killer feature is a one-click **"Teach Claude this handbook"** that feeds the whole guide into a local Claude session in 30 seconds.

### Why it fits the Resources section
- Lives under "Tutorials, guides, and deep-dives" → visual guide is a valid subtype
- Sits naturally next to **Claude Code Cheat Sheet** (also a Reference/Field Guide type)
- Zero install, browser-based, always current (v1.1.9+)

### Companion repo
[https://github.com/lilhawk7077/claude-code-resources](https://github.com/lilhawk7077/claude-code-resources) — MIT licensed.

### Checklist
- [x] Entry format matches existing rows in the table
- [x] Description is concise and informative
- [x] URL works and is the canonical homepage
- [x] No duplicate of existing entry
- [x] Companion repo MIT-licensed and actively maintained

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Resources section with a new reference for “Vexilo · A field guide to Claude Code.”
  * Added a link to the Vexilo site and a brief description highlighting its interactive index and quick-start guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->