### PR TITLE
add remoteopenclaw to ecosystem and related awesome lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -1162,6 +1162,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [voidly-mcp-server](https://github.com/voidly-ai/mcp-server) | new | 116 tools for Claude Code covering censorship intelligence (19.6M OONI measurements, 126 countries), E2E encrypted agent-to-agent messaging, and agent payments. Install: `claude mcp add voidly -- npx -y @voidly/mcp-server` |
 | [systemprompt-template](https://github.com/systempromptio/systemprompt-template) | -- | Governance infrastructure for Claude Code. Single compiled Rust binary that authenticates, authorises, rate-limits, logs, and attributes costs for every AI interaction before it reaches a tool or database. Self-hosted, air-gap capable, MCP + A2A compatible. BSL-1.1 |
 | [llm-prices](https://github.com/benbencodes/llm-prices) | new | CLI + Python library + MCP server to look up and compare LLM API costs across 167 models from 23 providers (OpenAI, Anthropic, Google, xAI, DeepSeek, Groq, and more). Ask Claude "what's the cheapest model for 10k input + 2k output?" before making API calls. Zero deps, no API key. `pipx install git+https://github.com/benbencodes/llm-prices` |
+| [RemoteOpenClaw MCP](https://github.com/aidevelopers2/remoteopenclaw-mcp) | -- | MCP server that searches 13,870+ MCP servers and 4,384+ skills and plugins from the terminal for Claude Code, OpenClaw, Hermes, and Codex. Install: `claude mcp add remoteopenclaw -- npx -y remoteopenclaw` |
 
 ---
 
@@ -1206,6 +1207,7 @@ Tutorials, guides, and deep-dives on Claude Code.
 | [awesome-claude-design](https://github.com/rohitg00/awesome-claude-design) | ![Stars](https://img.shields.io/github/stars/rohitg00/awesome-claude-design?style=flat-square&label=) | DESIGN.md files grouped by aesthetic family (editorial, terminal, warm, data-dense, cinematic, playful, glass, brutalist, indie) + remix recipes + prompt packs for Claude Design (Anthropic Labs) |
 | [ai-skill](https://github.com/anomalyco/ai-skill) | - | AI skill discovery and management system - helps users find, evaluate, install and manage agent skills, tools, plugins and extensions |
 | [Awesome AI Startups](https://github.com/nowork-studio/awesome-ai-startups) | new | Curated directory of ~440 indie-built AI products (bootstrapped, pre-seed, angel-funded) across 18 categories — AI agents, coding tools, marketing, audio/voice, image/design, video, and more |
+| [RemoteOpenClaw](https://remoteopenclaw.com) | -- | Directory of 13,870+ MCP servers plus 4,384+ skills and plugins for Claude Code, OpenClaw, Hermes, and Codex |
 
 ## Contributing
 


### PR DESCRIPTION
hi, submitting remoteopenclaw for the toolkit.

remoteopenclaw is an mcp server (plus a web directory) that searches 13,870+ mcp servers and 4,384+ skills and plugins from the terminal, for claude code, openclaw, hermes, and codex. install is one line: claude mcp add remoteopenclaw -- npx -y remoteopenclaw

added two table rows, matching each table's existing columns:
- **Ecosystem**: the remoteopenclaw mcp server (name / stars / description)
- **Related Awesome Lists**: the remoteopenclaw directory (list / stars / focus)

kept the diff to just the two added rows. thanks for maintaining this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new ecosystem entry highlighting `RemoteOpenClaw`, including a terminal-based install example.
  * Added a related resources entry linking to a directory for MCP servers, skills, and plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->