### PR TITLE
Add ai-meeting plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Over 176 production-ready plugins that extend Claude Code with domain-specific c
 | [accessibility-checker](plugins/accessibility-checker/) | Scan for accessibility issues and fix ARIA attributes in web applications |
 | [adr-writer](plugins/adr-writer/) | Architecture Decision Records authoring and management |
 | [AgentLint](https://github.com/0xmariowu/AgentLint) | Lint your repo for AI agent compatibility. 33 evidence-backed checks across 5 dimensions. Claude Code plugin. |
+| [ai-meeting](https://github.com/bin1874/ai-meeting-skill) | Structured multi-agent decision reviews with Codex, Claude Code, and adapter-based CLI agents. Install: `/plugin marketplace add bin1874/ai-meeting-skill` |
 | [ai-prompt-lab](plugins/ai-prompt-lab/) | Improve and test AI prompts for better Claude Code interactions |
 | [analytics-reporter](plugins/analytics-reporter/) | Generate analytics reports and dashboard configurations from project data |
 | [android-developer](plugins/android-developer/) | Android and Kotlin development with Jetpack Compose |


### PR DESCRIPTION
## Summary

Adds `ai-meeting` to the plugin table.

`ai-meeting` provides structured multi-agent decision reviews with Codex, Claude Code, and adapter-based CLI agents. It is installable as a Claude Code plugin marketplace.

## Link

https://github.com/bin1874/ai-meeting-skill

## Validation

README-only addition; link checked via the public repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the `ai-meeting` plugin to the plugin list with a link and install command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->