### PR TITLE
Add agent-guardrails to Hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -838,6 +838,7 @@ If you prefer a typed, npm-installable foundation for writing hooks rather than 
 
 - [claude-code-hooks](https://github.com/Payshak/claude-code-hooks) — TypeScript SDK with `defineHook()`, typed event payloads for all 5 hook events, response builders, and unit-testable `.handle()` method. Zero dependencies.
 - [EchoCoding](https://github.com/launsion-boop/EchoCoding) — Audio layer for coding agents with hook-triggered SFX, ambient soundscape, and optional cloud TTS/ASR voice interaction. Works with Claude Code hooks and also supports Cursor/Windsurf, Codex CLI, and Gemini CLI.
+- [agent-guardrails](https://github.com/greggreg488/agent-guardrails) — Ready-to-use cross-agent guardrail hooks (Claude Code + Codex) from one shared rule engine, plus a Codex safe-full-auto layer that hard-blocks destructive commands (rm -rf, force-push, destructive SQL, payments) even under danger-full-access, with a kill-switch and append-only audit log. Fail-open, MIT.
 
 ### Installing Hooks
 


### PR DESCRIPTION
Adds **agent-guardrails** under Hooks → Related SDKs (closest existing spot for an external hooks project — happy to move it if you prefer a different section).

It is a ready-to-use cross-agent guardrail pack: 8 hooks that run on both Claude Code and Codex from one shared rule engine, plus a Codex safe-full-auto layer that hard-blocks destructive commands (rm -rf, force-push, destructive SQL, payments, outbound-send) even under danger-full-access, with a kill-switch and an append-only audit log.

Every Codex-hook fact is cited against the official Codex docs (SCHEMA_NOTES.md). Honest scope: it is defense-in-depth (a blocklist), not a sandbox replacement. Fail-open, MIT.

Disclosure: I am the author and it is a new project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the “Related SDKs” list to include **agent-guardrails**.
  * Added a short description of its cross-agent guardrail hooks, safer full-auto protections, kill-switch support, and append-only audit logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->