### PR TITLE
Add Quota Dashboard to Companion Apps & GUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1027,6 +1027,7 @@ claude-code-toolkit/               850+ files
 | [parallel-code](https://github.com/johannesjo/parallel-code) | 370+ | Run Claude Code, Codex, and Gemini side by side -- each in its own git worktree |
 | [Bernstein](https://github.com/sipyourdrink-ltd/bernstein) | 288 | Python orchestrator for 40+ CLI coding agents (Claude Code, Codex, Gemini CLI). Git worktree isolation, MCP server mode, HMAC audit trail. Plan-driven, deterministic. Apache-2.0 |
 | [Poirot](https://github.com/LeonardoCardoso/Poirot) | 96 | macOS app for browsing Claude Code sessions, viewing diffs, and re-running commands. Reads local transcripts, runs offline |
+| [Quota Dashboard](https://github.com/ryan-knowone/quota-dashboard) | new | Local-only, privacy-first static-site dashboard for tracking AI subscription quotas (Claude Code Max, Kimi, Z.ai). Runs entirely in the browser; tokens never leave your machine. [Live demo](https://ryan-knowone.github.io/quota-dashboard/?mock=1) |
 | [TokenEater](https://github.com/AThevon/TokenEater) | 179 | Native macOS menu bar app for monitoring Claude AI usage limits and watching coding sessions live |
 | [Claw](https://github.com/jamesrochabrun/Claw) | 86 | Native macOS app wrapping Claude Code SDK in Swift. Plan Mode, MCP Integration, Custom System Prompts |
 | [The Claude Protocol](https://github.com/AvivK5498/The-Claude-Protocol) | 149 | Enforcement layer wrapping Claude Code with 13 hooks -- blocks unsafe operations, enforces worktree isolation |


### PR DESCRIPTION
Add [Quota Dashboard](https://github.com/ryan-knowone/quota-dashboard) to the Companion Apps & GUIs section.

It's a local-only, privacy-first static-site dashboard for tracking AI subscription quota across Claude Code Max, Kimi, and Z.ai. Tokens stay in browser memory and only go to the provider APIs.

Live demo (no credentials needed): https://ryan-knowone.github.io/quota-dashboard/?mock=1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added **Quota Dashboard** to the “Companion Apps & GUIs” list, with a short description and live demo link.
  * Highlighted it as a local-only, privacy-first dashboard for tracking AI subscription quotas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->