### PR TITLE
Add quota-dashboard-mcp to Companion Apps & GUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1058,6 +1058,7 @@ claude-code-toolkit/               850+ files
 | [cctally](https://github.com/omrikais/cctally) | new | Track Claude Code subscription usage as a weekly $-per-1% trend. Local web dashboard, terminal UI, forecasts, threshold alerts. Apache-2.0, zero telemetry. |
 | [claude-code-notifier](https://github.com/saiso/claude-code-notifier) | new | Native macOS notifier for Claude Code. Swift + UserNotifications, custom Heroicons-derived icon (SF Symbols–free), click-through to your IDE (VS Code, Cursor, Windsurf, JetBrains, iTerm2, Terminal) via bundle ID swap, per-event sound labels, hardened inputs (allowlists, length caps, control-character stripping). Universal binary (arm64 + x86_64), macOS 12+, MIT |
 | [ToutKit](https://github.com/toutkit/toutkit) | new | Desktop notebook for AI CLIs (Claude Code, Codex, Gemini). Pairs a sidebar of notes with a built-in terminal and an in-app webview that renders whatever the AI writes — each note is a self-contained folder with its own SQLite, key/value store, attached files, and scripts, so a note can grow from a static page into a sortable table, dashboard, or research tool. Local-first, AGPL-3.0 |
+| [quota-dashboard-mcp](https://github.com/ryan-knowone/quota-dashboard-mcp) | new | MCP server + local web dashboard for real-time Claude Code Max, Kimi, and Z.ai subscription quota. Provider tokens are read from environment variables only and never persisted or transmitted anywhere except the provider APIs. Zero telemetry. Install: `npx -y quota-dashboard-mcp@latest` |
 
 ---
 


### PR DESCRIPTION
Add [quota-dashboard-mcp](https://github.com/ryan-knowone/quota-dashboard-mcp) to the Companion Apps & GUIs section.\n\n**Why it fits**\n- The toolkit is Claude Code-focused, and Claude Code Max users have no built-in way to see remaining subscription quota / reset time.\n- `quota-dashboard-mcp` is an MCP server + local web dashboard that surfaces real-time Claude Code Max quota alongside Kimi and Z.ai usage.\n- It runs entirely on localhost; provider tokens are read from environment variables only and are never persisted or sent anywhere except the provider APIs.\n\n**Install**\n```bash\nnpx -y quota-dashboard-mcp@latest\n```\n\n**Privacy note**\nZero telemetry. Tokens stay in env vars and browser memory only.\n\n_Disclosure: this is my own side project. I previously submitted a mock-only version (#609); this PR replaces it with the real API-integrated MCP server._\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new “Companion Apps & GUIs” entry for subscription quota monitoring.
  * Included setup details and a simple install command.
  * Highlighted privacy-focused notes about local handling of provider tokens and zero telemetry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->