### PR TITLE
Add AI Agent Safety Starter Pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Claude Code Toolkit
 
-**The most comprehensive toolkit for Claude Code -- 135 agents, 35 curated skills (+400,000 via [SkillKit](https://agenstskills.com)), 42 commands, 176+ plugins, 20 hooks, 15 rules, 7 templates, 15 MCP configs, 26 companion apps, 53 ecosystem entries, and more.**
+**The most comprehensive toolkit for Claude Code -- 135 agents, 35 curated skills (+400,000 via [SkillKit](https://agenstskills.com)), 42 commands, 176+ plugins, 20 hooks, 15 rules, 7 templates, 15 MCP configs, 26 companion apps, 54 ecosystem entries, and more.**
 
 <p align="center">
   <a href="https://trendshift.io/repositories/21839" target="_blank"><img src="https://trendshift.io/api/badge/repositories/21839" alt="rohitg00%2Fawesome-claude-code-toolkit | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
@@ -1075,6 +1075,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [claude-token-lens](https://github.com/wassimbensalem/claude-token-lens) | 587+ installs | Real-time token attribution from local Claude Code JSONL sessions — see which tool, agent, MCP server, or skill is burning your quota. Live Ink dashboard, burn rate, ETA, 5h + 7-day tracking, zero telemetry. `npm install -g claude-token-lens` |
 | [cc-statistics](https://github.com/androidZzT/cc-statistics) | 270+ | Three-in-one Claude Code stats: CLI + Web + native macOS SwiftUI panel. Token costs, code changes by language, efficiency scoring, weekly reports. Supports Codex and Cursor too |
 | [cc-discipline](https://github.com/TechHU-GS/cc-discipline) | new | Guardrails for Claude Code — shell hooks that physically block bad behavior (edit loops, skipped verification, destructive git), not just markdown rules. Streak-breaker hard-stops at 5 edits, pre-edit-guard enforces debugging process, 7 rules, 7 skills, 2 subagents. Interactive installer with append mode. `bash ~/.cc-discipline/init.sh` |
+| [AI Agent Safety Starter Pack](https://github.com/el-zachariah/ai-agent-safety-starter-pack) | new | Free repo preflight and command-hook starter pack for Claude Code, Codex, Cursor, and other AI coding agents. Includes a one-minute risk scorecard, red-flag-to-action matrix, handoff playbook, upgrade checklist, and copy-paste agent task prompt. |
 | [ccpm](https://github.com/automazeio/ccpm) | 7,600+ | Project management with GitHub Issues + Git worktrees for parallel agent execution |
 | [claude-code-system-prompts](https://github.com/Piebald-AI/claude-code-system-prompts) | 5,900+ | Extracted system prompts from Claude Code, updated for each release |
 | [claude-context](https://github.com/zilliztech/claude-context) | 5,600+ | Semantic code search MCP by Zilliz -- hybrid BM25 + vector search, ~40% token reduction |


### PR DESCRIPTION
## Summary
- Add AI Agent Safety Starter Pack to the Ecosystem table
- Update the ecosystem-entry count from 53 to 54

## Why
This free repo provides a lightweight preflight/checklist resource for Claude Code, Codex, Cursor, and other AI coding agents: risk scorecard, red-flag-to-action matrix, handoff playbook, upgrade checklist, and a copy-paste agent task prompt.

## Verification
- Ran README sanity checks confirming one new row, matching count text, and the expected GitHub URL



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the top-line toolkit tagline to reflect the latest ecosystem count.
  * Added a new ecosystem entry for **AI Agent Safety Starter Pack** with its GitHub link and brief description.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->