### PR TITLE
Add ConfigDeck to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1162,6 +1162,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [voidly-mcp-server](https://github.com/voidly-ai/mcp-server) | new | 116 tools for Claude Code covering censorship intelligence (19.6M OONI measurements, 126 countries), E2E encrypted agent-to-agent messaging, and agent payments. Install: `claude mcp add voidly -- npx -y @voidly/mcp-server` |
 | [systemprompt-template](https://github.com/systempromptio/systemprompt-template) | -- | Governance infrastructure for Claude Code. Single compiled Rust binary that authenticates, authorises, rate-limits, logs, and attributes costs for every AI interaction before it reaches a tool or database. Self-hosted, air-gap capable, MCP + A2A compatible. BSL-1.1 |
 | [llm-prices](https://github.com/benbencodes/llm-prices) | new | CLI + Python library + MCP server to look up and compare LLM API costs across 167 models from 23 providers (OpenAI, Anthropic, Google, xAI, DeepSeek, Groq, and more). Ask Claude "what's the cheapest model for 10k input + 2k output?" before making API calls. Zero deps, no API key. `pipx install git+https://github.com/benbencodes/llm-prices` |
+| [ConfigDeck](https://github.com/tepesama/configdeck-cli) | new | Marketplace and directory for Claude Code configs — search 1,200+ subagents, skills, commands, hooks and MCP and install into `.claude/` in one click or via `npx configdeck add`. Portable via agentskills.io, every listing safety-scanned. [configdeck.com](https://configdeck.com) |
 
 ---
 


### PR DESCRIPTION
Adds ConfigDeck to the Ecosystem section.

ConfigDeck (https://configdeck.com) is a marketplace and directory for Claude Code configs — subagents, skills, commands, hooks and MCP. Install from the web in one click or via the CLI: `npx configdeck add <name>`. The CLI is open source (MIT): https://github.com/tepesama/configdeck-cli

Independent project, not affiliated with Anthropic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README ecosystem list with a new ConfigDeck entry.
  * Added a brief description highlighting safety-scanned Claude Code configs and one-click installation into `.claude/` or via `npx configdeck add`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->