### PR TITLE
Add manifest-dev plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Over 176 production-ready plugins that extend Claude Code with domain-specific c
 | [lightcms](https://github.com/jonradoff/lightcms) | AI-native CMS with 41 MCP tools for managing websites through natural language — pages, templates, assets, themes, collections, redirects, and more with full content versioning |
 | [linear-helper](plugins/linear-helper/) | Linear issue tracking integration and workflow management |
 | [load-tester](plugins/load-tester/) | Load and stress testing for APIs and web services |
-| [manifest-dev](https://github.com/doodledood/manifest-dev) | 69+ | Manifest-driven workflows: /figure-out adversarial understanding, /define acceptance criteria, /do execution with an independent verifier per criterion |
+| [manifest-dev](https://github.com/doodledood/manifest-dev) | Manifest-driven workflows: /figure-out adversarial understanding, /define acceptance criteria, /do execution with an independent verifier per criterion |
 | [memory-profiler](plugins/memory-profiler/) | Memory leak detection and heap analysis |
 | [migrate-tool](plugins/migrate-tool/) | Generate database migrations and code migration scripts for framework upgrades |
 | [migration-generator](plugins/migration-generator/) | Database migration generation and rollback management |

--- a/README.md
+++ b/README.md
@@ -206,6 +206,7 @@ Over 176 production-ready plugins that extend Claude Code with domain-specific c
 | [lightcms](https://github.com/jonradoff/lightcms) | AI-native CMS with 41 MCP tools for managing websites through natural language — pages, templates, assets, themes, collections, redirects, and more with full content versioning |
 | [linear-helper](plugins/linear-helper/) | Linear issue tracking integration and workflow management |
 | [load-tester](plugins/load-tester/) | Load and stress testing for APIs and web services |
+| [manifest-dev](https://github.com/doodledood/manifest-dev) | 69+ | Manifest-driven workflows: /figure-out adversarial understanding, /define acceptance criteria, /do execution with an independent verifier per criterion |
 | [memory-profiler](plugins/memory-profiler/) | Memory leak detection and heap analysis |
 | [migrate-tool](plugins/migrate-tool/) | Generate database migrations and code migration scripts for framework upgrades |
 | [migration-generator](plugins/migration-generator/) | Database migration generation and rollback management |


### PR DESCRIPTION
What problem it solves: coding agents start building before the problem is understood and report done on self-assessment. manifest-dev separates understanding (/figure-out), acceptance definition (/define), and verified execution (/do) — one independent verifier per criterion decides done.

Who uses it: developers handing larger tasks to a coding agent who want a stop condition they can trust.
Attribution: original work, doodledood/manifest-dev (MIT).

Example: /figure-out "why do half my background jobs silently stall?" — it investigates the repo and presses the load-bearing question before any fix. Individual skills install via npx skills add doodledood/manifest-dev --skill figure-out.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new `manifest-dev` entry to the “All Plugins” list in the README.
  * Included a description of “manifest-driven workflows” and the available slash commands: `/figure-out adversarial understanding`, `/define acceptance criteria`, and `/do execution` (with an independent verifier per criterion).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->