### PR TITLE
Add Skillselion to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1162,6 +1162,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [voidly-mcp-server](https://github.com/voidly-ai/mcp-server) | new | 116 tools for Claude Code covering censorship intelligence (19.6M OONI measurements, 126 countries), E2E encrypted agent-to-agent messaging, and agent payments. Install: `claude mcp add voidly -- npx -y @voidly/mcp-server` |
 | [systemprompt-template](https://github.com/systempromptio/systemprompt-template) | -- | Governance infrastructure for Claude Code. Single compiled Rust binary that authenticates, authorises, rate-limits, logs, and attributes costs for every AI interaction before it reaches a tool or database. Self-hosted, air-gap capable, MCP + A2A compatible. BSL-1.1 |
 | [llm-prices](https://github.com/benbencodes/llm-prices) | new | CLI + Python library + MCP server to look up and compare LLM API costs across 167 models from 23 providers (OpenAI, Anthropic, Google, xAI, DeepSeek, Groq, and more). Ask Claude "what's the cheapest model for 10k input + 2k output?" before making API calls. Zero deps, no API key. `pipx install git+https://github.com/benbencodes/llm-prices` |
+| [Skillselion](https://skillselion.com) | new | Directory of thousands of community-vetted Claude Code skills, MCP servers & marketplaces ranked by real install counts. Its `skillselion-mcp` server lets an agent search and `load_skill` a real SKILL.md mid-task. `npx -y skillselion-mcp` |
 
 ---
 


### PR DESCRIPTION
Adds **[Skillselion](https://skillselion.com)** to the Ecosystem table — a directory of thousands of community-vetted Claude Code skills, MCP servers and marketplaces ranked by real install counts. Its `skillselion-mcp` server lets an agent search and `load_skill` a real SKILL.md mid-task. One row added, table format followed.