### PR TITLE
Add iris to Companion Apps & GUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1058,6 +1058,7 @@ claude-code-toolkit/               850+ files
 | [cctally](https://github.com/omrikais/cctally) | new | Track Claude Code subscription usage as a weekly $-per-1% trend. Local web dashboard, terminal UI, forecasts, threshold alerts. Apache-2.0, zero telemetry. |
 | [claude-code-notifier](https://github.com/saiso/claude-code-notifier) | new | Native macOS notifier for Claude Code. Swift + UserNotifications, custom Heroicons-derived icon (SF Symbols–free), click-through to your IDE (VS Code, Cursor, Windsurf, JetBrains, iTerm2, Terminal) via bundle ID swap, per-event sound labels, hardened inputs (allowlists, length caps, control-character stripping). Universal binary (arm64 + x86_64), macOS 12+, MIT |
 | [ToutKit](https://github.com/toutkit/toutkit) | new | Desktop notebook for AI CLIs (Claude Code, Codex, Gemini). Pairs a sidebar of notes with a built-in terminal and an in-app webview that renders whatever the AI writes — each note is a self-contained folder with its own SQLite, key/value store, attached files, and scripts, so a note can grow from a static page into a sortable table, dashboard, or research tool. Local-first, AGPL-3.0 |
+| [iris](https://github.com/itzenata/iris-tui) | new | Live terminal supervisor (TUI) for every active Claude Code session -- per-session status, model, tokens, estimated cost with an aggregate counter, live activity feed, tool-usage histogram, and one-pane approve/deny of pending tool calls via a PreToolUse hook. Rust, MIT. |
 
 ---
 


### PR DESCRIPTION
Adds [iris](https://github.com/itzenata/iris-tui) — a live supervisor TUI for every active Claude Code session. It tails the transcripts Claude Code writes (read-only, local-first, no telemetry): per-session status/model/tokens/estimated cost with an aggregate counter, live activity feed, tool-usage histogram, and centralized approve/deny of pending tool calls via a PreToolUse hook with a heartbeat fallback so sessions never hang.

Rust + ratatui, MIT, on crates.io as [iris-tui](https://crates.io/crates/iris-tui) (v0.2.0). Added at the end of the Companion Apps & GUIs table with `new` for stars, matching recent entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new entry in the Companion Apps & GUIs section for the **iris** project.
  * Included a brief description and “new” metadata, highlighting its terminal-based session supervision, status tracking, cost estimates, and tool-call approval support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->