### PR TITLE
Add fe-rail to All Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Over 176 production-ready plugins that extend Claude Code with domain-specific c
 | [experiment-tracker](plugins/experiment-tracker/) | ML experiment tracking with metrics logging and run comparison |
 | [explore](plugins/explore/) | Smart codebase exploration with dependency mapping and structure analysis |
 | [faf-skills](https://github.com/Wolfe-Jam/faf-skills) | 31 Claude Code skills for persistent project context (.faf, `application/vnd.faf+yaml`). Scoring, sync, testing, publishing, MCP server creation, architecture docs. Anthropic MCP #2759. |
+| [fe-rail](https://github.com/sh5623/fe-rail) | Frontend-focused Claude Code plugin automating the spec-build-review-PR workflow for Next.js App Router / Vite SPA + TypeScript, with Tailwind v3/v4 and shadcn/ui support. 15 sub-agents. |
 | [feature-dev](plugins/feature-dev/) | Full feature development workflow from spec to completion |
 | [fractal](https://github.com/rmolines/fractal) | Recursive project management plugin. Decomposes any goal into verifiable predicates, works on the riskiest unknown first. Features `/fractal:run` (idempotent state machine), `/fractal:init`, `/fractal:patch`, dry run mode, and incremental decomposition with re-evaluation. |
 | [finance-tracker](plugins/finance-tracker/) | Development cost tracking with time estimates and budget reporting |


### PR DESCRIPTION
Adds [fe-rail](https://github.com/sh5623/fe-rail) — a frontend-focused Claude Code plugin harness for Next.js App Router / Vite SPA + TypeScript, with Tailwind v3/v4 and shadcn/ui support. Automates the spec → build → review → PR workflow with 15 sub-agents.

Added as an external-link row (following the existing pattern used by entries like `great_cto`, `gstack`, `fractal`) rather than vendoring the source, since fe-rail is actively maintained and versioned in its own repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Plugins section in the README to include a new plugin entry for **fe-rail**.
  * Added a brief description and link for the plugin, highlighting its workflow automation capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->