### PR TITLE
Add VoxQueue to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1081,6 +1081,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [claude-skills](https://github.com/alirezarezvani/claude-skills) | 5,300+ | 192 skills across 9 domains with 254 Python automation tools |
 | [paco-framework](https://github.com/PenguinAlleyApps/paco-framework) | 1+ | Markdown-first multi-agent OS for Claude Code. Coordinates 3-16 specialized AI agents (Engineering, QA, Growth, Finance) with file-based dispatch, institutional memory, CEO Gate approval, and 24/7 scheduling. No Python required. MIT |
 | [peon-ping](https://github.com/PeonPing/peon-ping) | 3,900+ | Warcraft III Peon voice notifications for Claude Code and other agents |
+| [VoxQueue](https://github.com/frslvr/voxqueue) | new | Serialized TTS queue for Windows — speaks task-complete and AskUserQuestion announcements from concurrent Claude Code sessions one at a time. Tray, hotkeys, web dashboard, instant positional pause via mpv IPC |
 | [n8n-skills](https://github.com/czlonkowski/n8n-skills) | 3,400+ | Skills for building production-ready n8n workflows |
 | [claude-hooks-mastery](https://github.com/disler/claude-code-hooks-mastery) | 3,300+ | Complete mastery guide for Claude Code hooks with production-ready scripts |
 | [claude-supermemory](https://github.com/supermemoryai/claude-supermemory) | 2,300+ | Persistent memory across sessions using Supermemory |


### PR DESCRIPTION
Adds [VoxQueue](https://github.com/frslvr/voxqueue) to the Ecosystem table.

VoxQueue is a serialized TTS queue for Windows: Stop-hook and AskUserQuestion announcements from any number of concurrent Claude Code sessions are spoken one at a time through a single consumer with atomic job claims, so audio never overlaps. Controlled from a system tray icon, global hotkeys, and a web dashboard (queue, history with replay, live settings), with instant positional pause/resume via mpv JSON-IPC. MIT licensed.

Placed next to peon-ping as the other voice-notification entry.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added VoxQueue to the ecosystem list.
  * Described its Windows text-to-speech queue, task announcements, tray and hotkey controls, web dashboard, and positional pause support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->