### PR TITLE
Add fable-baton to All Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Over 176 production-ready plugins that extend Claude Code with domain-specific c
 | [experiment-tracker](plugins/experiment-tracker/) | ML experiment tracking with metrics logging and run comparison |
 | [explore](plugins/explore/) | Smart codebase exploration with dependency mapping and structure analysis |
 | [faf-skills](https://github.com/Wolfe-Jam/faf-skills) | 31 Claude Code skills for persistent project context (.faf, `application/vnd.faf+yaml`). Scoring, sync, testing, publishing, MCP server creation, architecture docs. Anthropic MCP #2759. |
+| [fable-baton](https://github.com/realgarit/fable-baton) | Makes Fable 5 the orchestrator: Fable keeps judgment, tiered Opus/Sonnet/Haiku subagents do the labor, and hooks enforce the delegation (per-prompt reminder plus a deterministic inline-call counter with a CI functional test). MIT. |
 | [feature-dev](plugins/feature-dev/) | Full feature development workflow from spec to completion |
 | [fractal](https://github.com/rmolines/fractal) | Recursive project management plugin. Decomposes any goal into verifiable predicates, works on the riskiest unknown first. Features `/fractal:run` (idempotent state machine), `/fractal:init`, `/fractal:patch`, dry run mode, and incremental decomposition with re-evaluation. |
 | [finance-tracker](plugins/finance-tracker/) | Development cost tracking with time estimates and budget reporting |


### PR DESCRIPTION
fable-baton is a Claude Code plugin that makes Fable 5 the orchestrator. Fable keeps judgment, tiered Opus/Sonnet/Haiku subagents do the labor, and hooks enforce the delegation with a per-prompt reminder plus a deterministic inline-call counter that has a CI functional test.

Adds one row to the All Plugins table in README.md, alphabetically placed between faf-skills and feature-dev, matching the format used by other externally hosted plugin entries in that table.

Repo: https://github.com/realgarit/fable-baton (MIT, v1.3.0).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the **fable-baton** plugin to the README’s “All Plugins” table.
  * Included its repository link and a brief overview of its orchestration and validation capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->