### PR TITLE
Add Chat Session Managers (local macOS history apps)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1027,6 +1027,7 @@ claude-code-toolkit/               850+ files
 | [parallel-code](https://github.com/johannesjo/parallel-code) | 370+ | Run Claude Code, Codex, and Gemini side by side -- each in its own git worktree |
 | [Bernstein](https://github.com/sipyourdrink-ltd/bernstein) | 288 | Python orchestrator for 40+ CLI coding agents (Claude Code, Codex, Gemini CLI). Git worktree isolation, MCP server mode, HMAC audit trail. Plan-driven, deterministic. Apache-2.0 |
 | [Poirot](https://github.com/LeonardoCardoso/Poirot) | 96 | macOS app for browsing Claude Code sessions, viewing diffs, and re-running commands. Reads local transcripts, runs offline |
+| [Chat Session Managers](https://github.com/czxxxczx73-cell/chat-session-managers) | new | Native macOS apps to browse, search, archive, and delete local Codex / Claude Code / Grok conversation history — local-only, Universal 2, bilingual EN/中文 |
 | [TokenEater](https://github.com/AThevon/TokenEater) | 179 | Native macOS menu bar app for monitoring Claude AI usage limits and watching coding sessions live |
 | [Claw](https://github.com/jamesrochabrun/Claw) | 86 | Native macOS app wrapping Claude Code SDK in Swift. Plan Mode, MCP Integration, Custom System Prompts |
 | [The Claude Protocol](https://github.com/AvivK5498/The-Claude-Protocol) | 149 | Enforcement layer wrapping Claude Code with 13 hooks -- blocks unsafe operations, enforces worktree isolation |


### PR DESCRIPTION
Adds [Chat Session Managers](https://github.com/czxxxczx73-cell/chat-session-managers) under Companion Apps & GUIs.

Native Universal 2 macOS apps for browsing/searching/archiving local Claude Code (and Codex/Grok) conversation history. Fully local-only, bilingual, MIT.

Placed near Poirot as a related session-history browser.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Chat Session Managers to the list of companion apps and GUIs.
  * Described support for browsing, searching, archiving, and deleting local conversation history.
  * Noted local-only storage, Universal 2 support, and English/Chinese language availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->