### PR TITLE
Add PokeTokenBar to Companion Apps & GUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1058,6 +1058,7 @@ claude-code-toolkit/               850+ files
 | [cctally](https://github.com/omrikais/cctally) | new | Track Claude Code subscription usage as a weekly $-per-1% trend. Local web dashboard, terminal UI, forecasts, threshold alerts. Apache-2.0, zero telemetry. |
 | [claude-code-notifier](https://github.com/saiso/claude-code-notifier) | new | Native macOS notifier for Claude Code. Swift + UserNotifications, custom Heroicons-derived icon (SF Symbols–free), click-through to your IDE (VS Code, Cursor, Windsurf, JetBrains, iTerm2, Terminal) via bundle ID swap, per-event sound labels, hardened inputs (allowlists, length caps, control-character stripping). Universal binary (arm64 + x86_64), macOS 12+, MIT |
 | [ToutKit](https://github.com/toutkit/toutkit) | new | Desktop notebook for AI CLIs (Claude Code, Codex, Gemini). Pairs a sidebar of notes with a built-in terminal and an in-app webview that renders whatever the AI writes — each note is a self-contained folder with its own SQLite, key/value store, attached files, and scripts, so a note can grow from a static page into a sortable table, dashboard, or research tool. Local-first, AGPL-3.0 |
+| [PokeTokenBar](https://github.com/chattymin/PokeTokenBar) | new | macOS menu bar app that reads local Claude Code, Codex & Gemini CLI logs to show today's token usage and official 5h/weekly limits — and turns that usage into a collectible companion that hatches, evolves through its real line, and fills a Pokédex. KO/EN/JA UI, MIT |
 
 ---
 


### PR DESCRIPTION
Adds **PokeTokenBar** to the Companion Apps & GUIs section.

- Open-source (MIT) macOS menu bar app that reads local Claude Code, Codex & Gemini CLI logs for today's token usage and official 5h/weekly limits.
- Distinguisher: turns usage into a collectible companion (hatch → evolve → Pokédex) — a menu-bar tracker with a reason to open it.
- Homebrew: `brew install --cask chattymin/tap/poke-token-bar`
- Repo: https://github.com/chattymin/PokeTokenBar

Slotted at the end of the Companion Apps & GUIs table, `Stars: new` per the recent-entry convention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added PokeTokenBar to the list of companion apps and GUIs.
  - Documented its macOS menu bar experience for viewing token usage, weekly limits, and collectible companion progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->