### PR TITLE
Add ditto plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Over 176 production-ready plugins that extend Claude Code with domain-specific c
 | [discuss](plugins/discuss/) | Debate implementation approaches with structured pros and cons analysis |
 | [claw-army/claude-node](https://github.com/claw-army/claude-node) | Python subprocess bridge for Claude Code CLI, giving Python code direct access to Claude Code native capabilities via stream-json |
 | [discoclaw](https://github.com/DiscoClaw/discoclaw) | Personal AI orchestrator that bridges Discord to Claude Code with durable memory, task tracking, and cron-based automation |
+| [ditto](https://github.com/ohad6k/ditto) | Mines local Claude Code and Codex histories into private, evidence-backed user profiles. Native Claude Code and Codex plugins, CLI, and local MCP server. |
 | [jarvis](https://github.com/Ramsbaby/jarvis) | Turns an idle Claude Max subscription into a 24/7 AI ops system — Discord bot, 76 scheduled tasks, 12 AI teams, local LanceDB RAG, 98% context compression via Nexus CIG, and 4-layer self-healing infrastructure. Uses `claude -p` headless mode at $0 extra cost. |
 | [jarvis-company-board](https://github.com/Ramsbaby/jarvis-company-board) | Real-time AI agent collaboration board built on Next.js 15 and SQLite WAL — 8 named AI board members debate decisions via SSE push, with a DEV task approval workflow and Railway deploy support. |
 | [dna-claude-analysis](https://github.com/shmlkv/dna-claude-analysis) | Personal genome analysis toolkit that analyzes raw DNA data across 17 categories and generates a terminal-style HTML dashboard |


### PR DESCRIPTION
Adds ditto to the external plugins table.

Ditto mines selected local Claude Code and Codex session history into private, evidence-backed user profiles. It ships four focused skills through native Claude Code and Codex plugins, plus a CLI and local MCP server. I maintain the submitted project.

Repository: https://github.com/ohad6k/ditto

Validation:
- one README row only
- no existing Ditto entry or open PR
- public, active, MIT-licensed source repository
- tests: https://github.com/ohad6k/ditto/actions/runs/29356554998
- HOL plugin scan: https://github.com/ohad6k/ditto/actions/runs/29356554723
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Ditto to the All Plugins catalog.
  * Noted its local code-history analysis capabilities and available integration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->