### PR TITLE
Add new-skill: anywrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Claude Code Toolkit
 
-**The most comprehensive toolkit for Claude Code -- 135 agents, 35 curated skills (+400,000 via [SkillKit](https://agenstskills.com)), 42 commands, 176+ plugins, 20 hooks, 15 rules, 7 templates, 15 MCP configs, 26 companion apps, 53 ecosystem entries, and more.**
+**The most comprehensive toolkit for Claude Code -- 135 agents, 36 curated skills (+400,000 via [SkillKit](https://agenstskills.com)), 42 commands, 176+ plugins, 20 hooks, 15 rules, 7 templates, 15 MCP configs, 26 companion apps, 53 ecosystem entries, and more.**
 
 <p align="center">
   <a href="https://trendshift.io/repositories/21839" target="_blank"><img src="https://trendshift.io/api/badge/repositories/21839" alt="rohitg00%2Fawesome-claude-code-toolkit | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
@@ -48,7 +48,7 @@ curl -fsSL https://raw.githubusercontent.com/rohitg00/awesome-claude-code-toolki
 
 - [Plugins](#plugins) (176+)
 - [Agents](#agents) (135)
-- [Skills](#skills) (35 curated + 28 community)
+- [Skills](#skills) (36 curated + 28 community)
 - [Commands](#commands) (42)
 - [Hooks](#hooks) (20 scripts)
 - [Rules](#rules) (15)
@@ -541,7 +541,7 @@ Reference an agent in your `CLAUDE.md`:
 
 ## Skills
 
-Thirty-five curated skill modules included in this repo, with access to **400,000+ additional skills** via the [SkillKit marketplace](https://agenstskills.com). Each included skill teaches Claude Code domain-specific patterns with code examples, anti-patterns, and checklists.
+Thirty-six curated skill modules included in this repo, with access to **400,000+ additional skills** via the [SkillKit marketplace](https://agenstskills.com). Each included skill teaches Claude Code domain-specific patterns with code examples, anti-patterns, and checklists.
 
 | Skill | Directory | What It Teaches |
 |-------|-----------|-----------------|
@@ -687,7 +687,7 @@ npx skillkit@latest install claude-code-toolkit/tdd-mastery
 
 ### 15,000+ Skills via SkillKit Marketplace
 
-This toolkit includes 35 curated skills. For access to **400,000+ additional skills** across every domain, use [SkillKit](https://agenstskills.com):
+This toolkit includes 36 curated skills. For access to **400,000+ additional skills** across every domain, use [SkillKit](https://agenstskills.com):
 
 ```bash
 npx skillkit@latest                    # Launch interactive TUI
@@ -997,7 +997,7 @@ claude-code-toolkit/               850+ files
     business-product/              12 agents
     orchestration/                 8 agents
     research-analysis/             11 agents
-  skills/                          35 SKILL.md files
+  skills/                          36 SKILL.md files
   commands/                        42 commands across 8 categories
   hooks/
     hooks.json                     25 hook entries

--- a/README.md
+++ b/README.md
@@ -581,6 +581,7 @@ Thirty-five curated skill modules included in this repo, with access to **400,00
 | Mobile Development | `skills/mobile-development/` | React Native, Flutter, responsive layouts |
 | Data Engineering | `skills/data-engineering/` | ETL pipelines, Spark, star schema, data quality |
 | LLM Integration | `skills/llm-integration/` | Streaming, function calling, RAG, cost optimization |
+| anywrite | `skills/anywrite/` | Drive Anytype from the CLI — objects, properties, tags, types, lists, files, chat, search across all 52 local-API endpoints |
 
 ### Community Skills
 

--- a/skills/anywrite/SKILL.md
+++ b/skills/anywrite/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: anywrite
+description: Drive Anytype from the CLI — create/update/search notes, tasks, and PKM objects, manage spaces, properties, tags, types, templates, lists, files, chat, and members via all 52 endpoints of the Anytype local API in one compiled binary
+---
+
+# anywrite
+
+`anywrite` is a compiled Bun/TypeScript CLI that talks to the Anytype desktop app's local HTTP API (`http://localhost:31009` by default). It covers all 52 endpoints of the Anytype local API spec (2025-11-08) — spaces, objects, properties, tags, types, templates, lists, chat, files, members, search, and auth — as a single binary with zero dependencies and no MCP server. Anytype desktop must be running for any command to work.
+
+## Auth
+
+```bash
+anywrite auth --status          # shows configured yes/no + active source, never the key itself
+anywrite auth                   # starts the challenge flow: a 4-digit code pops up in Anytype desktop
+anywrite auth --code 1234       # completes the exchange, writes ~/.anywrite/config.json
+```
+
+Config precedence: `ANYTYPE_API_KEY` env var → `~/.anywrite/config.json` → a read-only fallback to an existing `anytype-cli` key, if present. The API key is never printed or logged.
+
+## Command shape
+
+```bash
+anywrite <resource> <action> [positionals] [--flag value]
+
+anywrite --help                 # lists all resources
+anywrite objects --help         # actions + generated flags for one resource
+```
+
+Positionals for `space`/`type`/`property` accept either a **name or an id** — the CLI resolves names to ids automatically. Useful global flags: `--all` (paginate the full result set), `--pretty` (table view), `--json '<raw>'` (merge a raw JSON body, needed for search filters and `lists add`), `--property key=value` (format-aware, repeatable), `--file <path>` (upload), `--follow` (consume an SSE chat stream).
+
+## Workflows
+
+**Create structured content** — property → tags → type → objects → verify:
+```bash
+anywrite properties create <space> --format select --name Stage
+anywrite tags create <space> stage --color yellow --name Backlog
+anywrite types create <space> --layout action --name Ticket --plural_name Tickets
+anywrite objects create <space> --type ticket --name "Wire auth" --property stage=Backlog --body "notes"
+anywrite verify <space> <object_id> --property stage=Backlog --pretty
+```
+
+**Find and update by property** — tag id → filtered search → update → verify:
+```bash
+anywrite tags list <space> stage --pretty   # filters need the tag ID, not the name
+anywrite search space <space> --all --json '{"types":["ticket"],"filters":{"operator":"and","conditions":[{"property_key":"stage","condition":"eq","select":"<tag_id>"}]}}'
+anywrite objects update <space> <hit_id> --property stage=Shipped
+anywrite verify <space> <hit_id> --property stage=Shipped --pretty
+```
+
+## Quick reference — 12 resources
+
+```bash
+# spaces
+anywrite spaces list
+anywrite spaces create --name "My Space"
+
+# objects
+anywrite objects list <space> --all
+anywrite objects create <space> --type task --name "Buy milk" --body "notes here"
+anywrite objects update <space> <object_id> --markdown "..." --status "Done"
+anywrite objects delete <space> <object_id>          # archives (soft delete)
+
+# properties / tags / types
+anywrite properties create <space> --format select --name Priority
+anywrite tags create <space> <property_id> --color red --name Urgent
+anywrite types create <space> --layout basic --name Task --plural_name Tasks
+
+# templates (read-only)
+anywrite templates list <space> <type_id>
+
+# lists (add/remove only work on collections, not sets)
+anywrite lists add <space> <list_id> --json '{"objects":["obj_id_1","obj_id_2"]}'
+anywrite lists objects <space> <list_id> <view_id>
+
+# files
+anywrite files upload <space> --file /path/to/image.png
+anywrite files download <space> <file_id> --output /path/to/save.png
+
+# members (read-only)
+anywrite members list <space>
+
+# search — structured filters/sort go in the --json body
+anywrite search global --query "task" --types task
+anywrite search space <space> --query "task" --json '{"types":["task"]}'
+
+# chat
+anywrite chat send <space> <chat_id> --text "hello"
+anywrite chat messages <space> <chat_id> --all
+anywrite chat stream <space> <chat_id> --follow   # SSE, one JSON line per event
+
+# verify — composite client-side check after a batch mutation
+anywrite verify <space> <object_id...> --property status="To Do" --pretty
+```
+
+## Notes (all live-verified against the running Anytype desktop)
+
+- **The body flag differs by action.** `objects create` takes `--body`, `objects update` takes `--markdown`, and `objects get` returns content under `markdown`. Using the wrong flag silently ignores the content.
+- **Property flags are `--status` and `--property` only** — there is no per-property generated flag. An unknown flag is silently ignored, producing a successful create with the property simply missing.
+- **Search filters need the tag ID; `--property` takes the name.** Inside a `--json` filter body the API wants raw ids — a tag name returns a 400. Look the id up with `tags list` first.
+- **`lists add`/`lists remove` only work on collections**, not sets (sets are query-driven and read-only for membership).
+- **Delete is a soft archive everywhere and is idempotent** — deleting twice returns `archived: true` both times, never a 410.
+- **Object bodies round-trip semantically, not byte-identically** (code-fence language tags drop, blank lines collapse). Check key content instead of string-diffing a body to verify a write.
+- **Platform ceilings — no endpoint exists**, so the CLI can't do them: block-level editing, member invite/role management, template create/update/delete, and space deletion.
+
+## Errors
+
+Any 4xx/5xx from the API prints the response body verbatim to stderr and exits 1. A usage error (unknown resource/action, missing required flag, an unresolvable name) exits 2 with a short message and makes no API call.


### PR DESCRIPTION
## anywrite

Adds `skills/anywrite/` — a skill for driving Anytype from the command line.

`anywrite` is a compiled Bun/TypeScript CLI that talks to the Anytype desktop app's local HTTP API (`http://localhost:31009` by default). It covers **all 52 endpoints** of the Anytype local API spec (2025-11-08) — spaces, objects, properties, tags, types, templates, lists, chat, files, members, search, and auth — as a single binary with zero dependencies and no MCP server.

### What it does
- Create and update notes, tasks, and PKM objects; manage the full type system (properties, select/multi-select tags, custom types, templates).
- Structured search via a filter DSL, cursor/offset pagination handled transparently by `--all`, file upload/download, chat (including SSE streaming), and a composite `verify` command to confirm a batch mutation landed.
- Name-or-id resolution for spaces/types/properties, and `--property key=value` that is format-aware (resolves tag names, checkbox booleans, multi-value lists).

### Who it's for
Anytype users who want an agent (or a script) to manage their space without paying a per-tool MCP context tax — one binary, one predictable JSON-out CLI. Anytype desktop must be running.

### Notes captured in the skill
The SKILL.md documents live-verified behaviors that are easy to get wrong: the body flag differs per action (`--body` on create vs `--markdown` on update), search filters need the tag id (not the name), `lists add/remove` only work on collections, delete is a soft archive everywhere, and the platform ceilings where no endpoint exists.

Follows the CONTRIBUTING format: `skills/<name>/SKILL.md` with name + description frontmatter, and the README skills table is updated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the curated Skills count and Skills table to include the new `anywrite` skill.
  - Added documentation for `anywrite`, covering CLI usage, authentication flow, supported local API scope, examples for creating/searching/updating content, common flags/options, and standardized error handling.
  - Included quick-reference commands and notes on idempotent behavior, property/tag handling, body round-tripping, and platform limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->