### PR TITLE
Add oss-distributor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1162,6 +1162,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [voidly-mcp-server](https://github.com/voidly-ai/mcp-server) | new | 116 tools for Claude Code covering censorship intelligence (19.6M OONI measurements, 126 countries), E2E encrypted agent-to-agent messaging, and agent payments. Install: `claude mcp add voidly -- npx -y @voidly/mcp-server` |
 | [systemprompt-template](https://github.com/systempromptio/systemprompt-template) | -- | Governance infrastructure for Claude Code. Single compiled Rust binary that authenticates, authorises, rate-limits, logs, and attributes costs for every AI interaction before it reaches a tool or database. Self-hosted, air-gap capable, MCP + A2A compatible. BSL-1.1 |
 | [llm-prices](https://github.com/benbencodes/llm-prices) | new | CLI + Python library + MCP server to look up and compare LLM API costs across 167 models from 23 providers (OpenAI, Anthropic, Google, xAI, DeepSeek, Groq, and more). Ask Claude "what's the cheapest model for 10k input + 2k output?" before making API calls. Zero deps, no API key. `pipx install git+https://github.com/benbencodes/llm-prices` |
+| [oss-distributor](https://github.com/yarin-hochman1/oss-distributor) | 1 | A Claude Code agent that gets your open-source project listed in GitHub awesome-lists and registries, with an approval gate before anything gets submitted. `git clone https://github.com/yarin-hochman1/oss-distributor ~/.claude/agents/oss-distributor` |
 
 ---
 


### PR DESCRIPTION
Adds [oss-distributor](https://github.com/yarin-hochman1/oss-distributor) to the Ecosystem section.

**What it is**: Refreshes a live GitHub snapshot of your repo, searches for awesome-lists and registries that fit your project's ecosystem, scores each candidate for fit, and opens pull requests only after you explicitly approve. Rate-limited to 5 PRs per session, skips lists that require human-only attestations, and never invents statistics about your project.

**License**: MIT
**Install**:
```
git clone https://github.com/yarin-hochman1/oss-distributor ~/.claude/agents/oss-distributor
```

Fits under Ecosystem because it's a "notable project/resource across the Claude Code ecosystem" in the same vein as the other listed tools/CLIs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added oss-distributor to the Ecosystem list, including its description, star count, and local installation path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->