### PR TITLE
Add: Running Claude Code Unattended guide to Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1190,6 +1190,7 @@ Tutorials, guides, and deep-dives on Claude Code.
 | [Dispatch & Remote Control](https://claude.com/blog/dispatch-and-computer-use) | Blog | Run Claude Code from phone/web, schedule recurring tasks, remote session control |
 | [Claude Code Cheat Sheet](https://cc.storyfox.cz/) | Reference | One-page printable reference, auto-updated daily, 4 languages |
 | [Multi-Agent Orchestra](https://addyosmani.com/blog/code-agent-orchestra/) | Blog | Addy Osmani's survey of multi-agent coding patterns |
+| [Running Claude Code Unattended](https://github.com/joeyycli/agent-ops-kit-guide) | Guide | Free write-up of the pattern for running Claude Code as a scheduled, unattended process — systemd lock/timeout/backstop-commit, prompt-injection defense via authority order, file-based memory, spend rails ([site](https://joeyycli.github.io/agent-ops-kit-guide/)) |
 
 ## Related Awesome Lists
 


### PR DESCRIPTION
Adds a free guide repo to the Resources table: [Running Claude Code Unattended](https://github.com/joeyycli/agent-ops-kit-guide) — a write-up of the pattern for running Claude Code as a scheduled/unattended process (systemd lock/timeout/backstop-commit, prompt-injection defense via authority order, file-based memory across sessions, spend rails for autonomous spending). Also readable as a site at https://joeyycli.github.io/agent-ops-kit-guide/. Distinct angle from the existing Resources entries (interactive use, hooks, context engineering) — this one is specifically about autonomous/scheduled operation.

Disclosure: I maintain this guide repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a resource covering unattended Claude Code workflows, including scheduling, guardrails, prompt-injection defenses, file-based memory, and spend controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->