### PR TITLE
Add CooCoo to Companion Apps & GUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1058,7 +1058,7 @@ claude-code-toolkit/               850+ files
 | [cctally](https://github.com/omrikais/cctally) | new | Track Claude Code subscription usage as a weekly $-per-1% trend. Local web dashboard, terminal UI, forecasts, threshold alerts. Apache-2.0, zero telemetry. |
 | [claude-code-notifier](https://github.com/saiso/claude-code-notifier) | new | Native macOS notifier for Claude Code. Swift + UserNotifications, custom Heroicons-derived icon (SF Symbols–free), click-through to your IDE (VS Code, Cursor, Windsurf, JetBrains, iTerm2, Terminal) via bundle ID swap, per-event sound labels, hardened inputs (allowlists, length caps, control-character stripping). Universal binary (arm64 + x86_64), macOS 12+, MIT |
 | [ToutKit](https://github.com/toutkit/toutkit) | new | Desktop notebook for AI CLIs (Claude Code, Codex, Gemini). Pairs a sidebar of notes with a built-in terminal and an in-app webview that renders whatever the AI writes — each note is a self-contained folder with its own SQLite, key/value store, attached files, and scripts, so a note can grow from a static page into a sortable table, dashboard, or research tool. Local-first, AGPL-3.0 |
-| [CooCoo](https://github.com/zzunaid/coo-coo) | new | Native macOS menu bar companion for Claude Code -- 6 animated characters, floating widget, sound + notification alerts via Claude Code's hook system (not PTY parsing), fully local. Swift/SwiftUI, MIT |
+| [CooCoo](https://github.com/zzunaid/coo-coo) | new | Native macOS menu bar companion for Claude Code -- 6 animated characters, floating widget, sound + notification alerts via Claude Code's hook system (not PTY parsing). Core alerting is local-only; anonymous Firebase Analytics events also sent. Swift/SwiftUI, MIT |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1058,6 +1058,7 @@ claude-code-toolkit/               850+ files
 | [cctally](https://github.com/omrikais/cctally) | new | Track Claude Code subscription usage as a weekly $-per-1% trend. Local web dashboard, terminal UI, forecasts, threshold alerts. Apache-2.0, zero telemetry. |
 | [claude-code-notifier](https://github.com/saiso/claude-code-notifier) | new | Native macOS notifier for Claude Code. Swift + UserNotifications, custom Heroicons-derived icon (SF Symbols–free), click-through to your IDE (VS Code, Cursor, Windsurf, JetBrains, iTerm2, Terminal) via bundle ID swap, per-event sound labels, hardened inputs (allowlists, length caps, control-character stripping). Universal binary (arm64 + x86_64), macOS 12+, MIT |
 | [ToutKit](https://github.com/toutkit/toutkit) | new | Desktop notebook for AI CLIs (Claude Code, Codex, Gemini). Pairs a sidebar of notes with a built-in terminal and an in-app webview that renders whatever the AI writes — each note is a self-contained folder with its own SQLite, key/value store, attached files, and scripts, so a note can grow from a static page into a sortable table, dashboard, or research tool. Local-first, AGPL-3.0 |
+| [CooCoo](https://github.com/zzunaid/coo-coo) | new | Native macOS menu bar companion for Claude Code -- 6 animated characters, floating widget, sound + notification alerts via Claude Code's hook system (not PTY parsing), fully local. Swift/SwiftUI, MIT |
 
 ---
 


### PR DESCRIPTION
Adds CooCoo, a native macOS menu bar app that alerts you (animated icon, sound, native notification) the moment Claude Code needs input.

- Uses Claude Code's own hook system (`Notification`/`PreToolUse`/`Stop`), not PTY parsing or polling — a hook fires, a local script sends one JSON packet to `127.0.0.1:47291`, the app reacts
- 6 selectable animated characters, plus a draggable floating widget
- Fully local for the core feature; MIT licensed
- Swift/SwiftUI, signed and notarized

Repo: https://github.com/zzunaid/coo-coo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the “Companion Apps & GUIs” section to include **CooCoo**, with a link to the project and an overview of its native macOS menu bar companion (including animated characters and alerting behavior).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->