### PR TITLE
Add claude-predeploy to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1162,6 +1162,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [voidly-mcp-server](https://github.com/voidly-ai/mcp-server) | new | 116 tools for Claude Code covering censorship intelligence (19.6M OONI measurements, 126 countries), E2E encrypted agent-to-agent messaging, and agent payments. Install: `claude mcp add voidly -- npx -y @voidly/mcp-server` |
 | [systemprompt-template](https://github.com/systempromptio/systemprompt-template) | -- | Governance infrastructure for Claude Code. Single compiled Rust binary that authenticates, authorises, rate-limits, logs, and attributes costs for every AI interaction before it reaches a tool or database. Self-hosted, air-gap capable, MCP + A2A compatible. BSL-1.1 |
 | [llm-prices](https://github.com/benbencodes/llm-prices) | new | CLI + Python library + MCP server to look up and compare LLM API costs across 167 models from 23 providers (OpenAI, Anthropic, Google, xAI, DeepSeek, Groq, and more). Ask Claude "what's the cheapest model for 10k input + 2k output?" before making API calls. Zero deps, no API key. `pipx install git+https://github.com/benbencodes/llm-prices` |
+| [claude-predeploy](https://github.com/IsaacYap90/claude-predeploy) | new | Pre-deploy safety gate for Claude Code — verifies your deploy candidate is a git-descendant of what's actually live (so it can't silently drop a route or feature) and confirms the rollback path works, before you ship. Load-bearing checks are deterministic exit-code scripts; AI agents add code/security/visual/SEO judgment on top. MIT |
 
 ---
 


### PR DESCRIPTION
Adds **claude-predeploy** to the Ecosystem section.

Pre-deploy safety gate for Claude Code: it verifies your deploy candidate is a git-descendant of what's actually live (so it can't silently drop a route or feature) and confirms the rollback path works, before you ship. Load-bearing checks are deterministic exit-code scripts; AI agents add code/security/visual/SEO judgment on top.

- Repo: https://github.com/IsaacYap90/claude-predeploy
- License: MIT

One-line addition to the Ecosystem table, matching the existing `| [name](link) | Stars | Description |` format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added `claude-predeploy` to the Ecosystem section.
  - Described its pre-deployment safety checks, rollback verification, optional AI capabilities, and MIT license.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->