### PR TITLE
Add Alex to the ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1067,6 +1067,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 
 | Name | Stars | Description |
 |------|-------|-------------|
+| [Alex](https://github.com/madhavajay/alex) | 28+ | Local Rust proxy with an optional UI that routes Claude Code and other coding agents across providers, with local request/cost/session/tool traces, scriptable middleware, subscription bonding, failover, and messenger-assisted re-authentication |
 | [claude-mem](https://github.com/thedotmack/claude-mem) | 35,900+ | Auto-captures everything Claude does, compresses with AI, injects context into future sessions. #1 trending GitHub Feb 2026 |
 | [wshobson/agents](https://github.com/wshobson/agents) | 31,300+ | 112 specialized agents, 16 orchestrators, 146 skills, 79 tools in 72 focused plugins |
 | [oh-my-claudecode](https://github.com/Yeachan-Heo/oh-my-claudecode) | 9,900+ | Teams-first multi-agent orchestration with 19 specialized agents and 28 skills |

--- a/README.md
+++ b/README.md
@@ -1067,7 +1067,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 
 | Name | Stars | Description |
 |------|-------|-------------|
-| [Alex](https://github.com/madhavajay/alex) | 28+ | Local Rust proxy with an optional UI that routes Claude Code and other coding agents across providers, with local request/cost/session/tool traces, scriptable middleware, subscription bonding, failover, and messenger-assisted re-authentication |
+| [Alex](https://github.com/madhavajay/alex) | 28+ | Local Rust proxy with an optional UI that routes Claude Code and other coding agents across providers, with local request/cost/session/tool traces, failover middleware, subscription bonding, and telegram re-authentication |
 | [claude-mem](https://github.com/thedotmack/claude-mem) | 35,900+ | Auto-captures everything Claude does, compresses with AI, injects context into future sessions. #1 trending GitHub Feb 2026 |
 | [wshobson/agents](https://github.com/wshobson/agents) | 31,300+ | 112 specialized agents, 16 orchestrators, 146 skills, 79 tools in 72 focused plugins |
 | [oh-my-claudecode](https://github.com/Yeachan-Heo/oh-my-claudecode) | 9,900+ | Teams-first multi-agent orchestration with 19 specialized agents and 28 skills |


### PR DESCRIPTION
Adds Alex, a local Rust proxy with an optional UI for Claude Code and other coding agents. It provides local request, cost, session, and tool traces, scriptable middleware, subscription bonding, failover, and IM re-authentication.

I'm the maintainer. Thanks!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Ecosystem section to add **Alex**, a local Rust proxy with an optional UI that routes coding agents across providers, including request/cost/session/tool tracing, failover middleware, subscription bonding, and Telegram re-authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->