### PR TITLE
Add Claude Sessions Tray to Companion Apps & GUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1058,6 +1058,7 @@ claude-code-toolkit/               850+ files
 | [cctally](https://github.com/omrikais/cctally) | new | Track Claude Code subscription usage as a weekly $-per-1% trend. Local web dashboard, terminal UI, forecasts, threshold alerts. Apache-2.0, zero telemetry. |
 | [claude-code-notifier](https://github.com/saiso/claude-code-notifier) | new | Native macOS notifier for Claude Code. Swift + UserNotifications, custom Heroicons-derived icon (SF Symbols–free), click-through to your IDE (VS Code, Cursor, Windsurf, JetBrains, iTerm2, Terminal) via bundle ID swap, per-event sound labels, hardened inputs (allowlists, length caps, control-character stripping). Universal binary (arm64 + x86_64), macOS 12+, MIT |
 | [ToutKit](https://github.com/toutkit/toutkit) | new | Desktop notebook for AI CLIs (Claude Code, Codex, Gemini). Pairs a sidebar of notes with a built-in terminal and an in-app webview that renders whatever the AI writes — each note is a self-contained folder with its own SQLite, key/value store, attached files, and scripts, so a note can grow from a static page into a sortable table, dashboard, or research tool. Local-first, AGPL-3.0 |
+| [Claude Sessions Tray](https://github.com/corentin-core/claude-sessions-tray) | new | GNOME/Linux tray listing all Claude Code sessions across every folder, with a per-session status dot (working, ready, idle, stuck). Full-text history search, per-day token usage by model and folder, desktop notifications; a companion GNOME Shell extension raises the right VSCode window under Wayland. MIT |
 
 ---
 


### PR DESCRIPTION
Adds **Claude Sessions Tray** to Companion Apps & GUIs.

A GNOME/Linux tray for managing Claude Code sessions across folders. The section already has macOS/Windows equivalents (TokenEater, WhereMyTokens, aby-claude-watcher) but no GNOME/Linux one yet.

- Repo: https://github.com/corentin-core/claude-sessions-tray (MIT)
- Lists every session across all folders with a per-session status (working / ready / idle / stuck), full-text history search, per-day token usage by model and folder, and desktop notifications. A companion GNOME Shell extension raises the right VSCode window under Wayland.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Claude Sessions Tray to the list of companion apps and GUIs.
  * Included details about its GNOME/Linux tray features, session status, token history, notifications, GNOME Shell extension, license, and repository link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->