### PR TITLE
feat: add sparda-skills (Proof-Carrying Code for Agents)

### DIFF
--- a/README.md
+++ b/README.md
@@ -675,6 +675,7 @@ Thirty-five curated skill modules included in this repo, with access to **400,00
 | [BlogBurst](https://github.com/shensi8312/blogburst-claude-skill) | `git clone https://github.com/shensi8312/blogburst-claude-skill ~/.claude/skills/blogburst` | Autonomous social media manager for Twitter/Bluesky/Telegram/Discord — writes posts, replies, learns what works. Replaces a $500-1,500/mo freelance SMM for $29-99/mo. Public endpoints demo content before signup. |
 | [Gear Foundation Skills](https://github.com/gear-foundation/vara-skills) | [Repo](https://github.com/gear-foundation/vara-skills) | 21 skills teaching AI coding agents to build and ship Rust smart contracts on Vara Network with Gear/Sails. Covers planning, implementation, testing, frontend, indexing, on-chain deployment, and safe program evolution. MIT. |
 | [Superpower Builder](https://github.com/redhuntlabs/superpower-builder) | `/plugin marketplace add redhuntlabs/superpower-builder` then `/plugin install superpower-builder@superpower-builder` | Interview-driven meta-builder that turns recurring tasks into reusable `SKILL.md` files. Routes by workflow/discipline/content/subagent kind, then pressure-tests baseline-without-skill vs. with-skill before saving. MIT, no telemetry. |
+| [sparda-skills](https://github.com/zyx77550/sparda-skills) | `git clone https://github.com/zyx77550/sparda-skills ~/.claude/skills/sparda-skills` | Connects AI coding agents to the SPARDA Security Gate. Validates agent edits against invariants before applying them. |
 
 ### Installing Skills
 


### PR DESCRIPTION
Adds sparda-skills, a skill that connects AI coding agents to the SPARDA Security Gate to validate agent edits against runtime invariants before applying them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the `sparda-skills` community skill to the README, including installation instructions and a brief description of its security validation capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->