### PR TITLE
Add ai-notify to the plugins list

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ Over 176 production-ready plugins that extend Claude Code with domain-specific c
 | [accessibility-checker](plugins/accessibility-checker/) | Scan for accessibility issues and fix ARIA attributes in web applications |
 | [adr-writer](plugins/adr-writer/) | Architecture Decision Records authoring and management |
 | [AgentLint](https://github.com/0xmariowu/AgentLint) | Lint your repo for AI agent compatibility. 33 evidence-backed checks across 5 dimensions. Claude Code plugin. |
+| [ai-notify](https://github.com/Helias/ai-notify) | Sound alerts when Claude Code, Codex, or opencode finish or need attention — only when the terminal is unfocused. Linux, macOS, and Windows, hook-based, one-command install |
 | [ai-prompt-lab](plugins/ai-prompt-lab/) | Improve and test AI prompts for better Claude Code interactions |
 | [analytics-reporter](plugins/analytics-reporter/) | Generate analytics reports and dashboard configurations from project data |
 | [android-developer](plugins/android-developer/) | Android and Kotlin development with Jetpack Compose |


### PR DESCRIPTION
Adds [ai-notify](https://github.com/Helias/ai-notify), a small hook-based tool that plays a sound when Claude Code (or Codex/opencode) finishes or needs attention, but only when the terminal window is unfocused. Works on Linux, macOS, and Windows, installs with one command.

related medium article: https://medium.com/engineering-in-the-age-of-ai/ai-notify-context-aware-notifications-for-multi-tasking-developers-3614635398ec

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the **ai-notify** plugin to the plugin catalog.
  * Documented sound alerts for task completion or attention requests when the terminal is unfocused, with Linux, macOS, and Windows support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->