### PR TITLE
Add ClaudeVoice: voice + phone notifier for Claude Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1058,6 +1058,7 @@ claude-code-toolkit/               850+ files
 | [cctally](https://github.com/omrikais/cctally) | new | Track Claude Code subscription usage as a weekly $-per-1% trend. Local web dashboard, terminal UI, forecasts, threshold alerts. Apache-2.0, zero telemetry. |
 | [claude-code-notifier](https://github.com/saiso/claude-code-notifier) | new | Native macOS notifier for Claude Code. Swift + UserNotifications, custom Heroicons-derived icon (SF Symbols–free), click-through to your IDE (VS Code, Cursor, Windsurf, JetBrains, iTerm2, Terminal) via bundle ID swap, per-event sound labels, hardened inputs (allowlists, length caps, control-character stripping). Universal binary (arm64 + x86_64), macOS 12+, MIT |
 | [ToutKit](https://github.com/toutkit/toutkit) | new | Desktop notebook for AI CLIs (Claude Code, Codex, Gemini). Pairs a sidebar of notes with a built-in terminal and an in-app webview that renders whatever the AI writes — each note is a self-contained folder with its own SQLite, key/value store, attached files, and scripts, so a note can grow from a static page into a sortable table, dashboard, or research tool. Local-first, AGPL-3.0 |
+| [ClaudeVoice](https://github.com/sunlinhua-dotcom/claudevoice) | new | Global voice + phone-push notifications for Claude Code. Hooks (Stop/Notification/SubagentStop) announce which session finished or needs input, across every project. macOS-first, free (Edge TTS, no API key), zero-dependency Node, MIT |
 
 ---
 


### PR DESCRIPTION
Adds **ClaudeVoice** to *Companion Apps & GUIs*.

**Repo:** https://github.com/sunlinhua-dotcom/claudevoice (MIT)

Global voice + phone-push notifications for Claude Code. It installs Claude Code hooks (Stop / Notification / SubagentStop) once and then announces out loud — and can push to your phone — which session finished or is waiting on your input, across every project, with a distinct color and voice per project.

- Free, no API key (uses Microsoft Edge neural TTS by default; Azure/MiMo optional)
- Zero-dependency Node server; the hook never blocks Claude
- Optional native macOS menubar app; optional phone push via Cloudflare Worker / Telegram / Feishu
- macOS-first, MIT

Sits alongside existing entries like `claude-code-notifier` and `aby-claude-watcher`. Single table row added at the end of the *Companion Apps & GUIs* section; `new` in the Stars column per the convention for brand-new repos.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added ClaudeVoice to the list of companion apps and graphical interfaces.
  * Described its macOS voice and phone-push notification capabilities for Claude Code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->