### PR TITLE
Add Garcon to Companion Apps & GUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1058,6 +1058,7 @@ claude-code-toolkit/               850+ files
 | [cctally](https://github.com/omrikais/cctally) | new | Track Claude Code subscription usage as a weekly $-per-1% trend. Local web dashboard, terminal UI, forecasts, threshold alerts. Apache-2.0, zero telemetry. |
 | [claude-code-notifier](https://github.com/saiso/claude-code-notifier) | new | Native macOS notifier for Claude Code. Swift + UserNotifications, custom Heroicons-derived icon (SF Symbols–free), click-through to your IDE (VS Code, Cursor, Windsurf, JetBrains, iTerm2, Terminal) via bundle ID swap, per-event sound labels, hardened inputs (allowlists, length caps, control-character stripping). Universal binary (arm64 + x86_64), macOS 12+, MIT |
 | [ToutKit](https://github.com/toutkit/toutkit) | new | Desktop notebook for AI CLIs (Claude Code, Codex, Gemini). Pairs a sidebar of notes with a built-in terminal and an in-app webview that renders whatever the AI writes — each note is a self-contained folder with its own SQLite, key/value store, attached files, and scripts, so a note can grow from a static page into a sortable table, dashboard, or research tool. Local-first, AGPL-3.0 |
+| [Garcon](https://github.com/cfal/garcon) | 40 | Self-hosted browser and mobile workspace for parallel Claude Code, Codex, Cursor Agent, OpenCode, Amp, Droid, and Pi sessions, with live steering, integrated terminal/files/diffs, Git and PR workflows, mobile approvals, scheduling, and cross-agent transfers |
 
 ---
 


### PR DESCRIPTION
Adds [Garcon](https://github.com/cfal/garcon) to **Companion Apps & GUIs**.

Garcon is a self-hosted browser and mobile workspace for parallel Claude Code, Codex, Cursor Agent, OpenCode, Amp, Droid, and Pi sessions, with live steering, integrated terminal/files/diffs, Git and pull-request workflows, mobile approvals, scheduling, and cross-agent transfers.

The entry is appended to the table to match the ordering of recent additions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Garcon to the list of companion apps and GUIs, highlighting its browser and mobile workspace features for managing coding sessions, files, diffs, terminals, and pull request workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->