### PR TITLE
Add Formo Analytics skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -676,6 +676,8 @@ Thirty-five curated skill modules included in this repo, with access to **400,00
 | [Gear Foundation Skills](https://github.com/gear-foundation/vara-skills) | [Repo](https://github.com/gear-foundation/vara-skills) | 21 skills teaching AI coding agents to build and ship Rust smart contracts on Vara Network with Gear/Sails. Covers planning, implementation, testing, frontend, indexing, on-chain deployment, and safe program evolution. MIT. |
 | [Superpower Builder](https://github.com/redhuntlabs/superpower-builder) | `/plugin marketplace add redhuntlabs/superpower-builder` then `/plugin install superpower-builder@superpower-builder` | Interview-driven meta-builder that turns recurring tasks into reusable `SKILL.md` files. Routes by workflow/discipline/content/subagent kind, then pressure-tests baseline-without-skill vs. with-skill before saving. MIT, no telemetry. |
 
+| [Formo Analytics](https://github.com/getformo/cli/tree/main/skills/formo-analytics) | `npx @formo/cli` | Query [Formo](https://formo.so) product and onchain analytics through MCP, CLI, or REST — KPIs, SQL, funnels, retention, revenue, users, and wallet profiles |
+
 ### Installing Skills
 
 **Browse and install via SkillKit** (recommended):


### PR DESCRIPTION
Adds the public Formo Analytics skill to Community Skills using the existing table format.

The skill lets Claude Code and other agents query [Formo](https://formo.so) product and onchain analytics through MCP, CLI, or REST, including KPIs, SQL, funnels, retention, revenue, users, and wallet profiles.

Skill source: https://github.com/getformo/cli/tree/main/skills/formo-analytics

Validation: the skill and product links resolve and the Markdown diff passes `git diff --check`.

Disclosure: I maintain Formo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Formo Analytics to the Community Skills list.
  * Included its repository link and suggested installation command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->