### PR TITLE
Add areco to Companion Apps & GUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Claude Code Toolkit
 
-**The most comprehensive toolkit for Claude Code -- 135 agents, 35 curated skills (+400,000 via [SkillKit](https://agenstskills.com)), 42 commands, 176+ plugins, 20 hooks, 15 rules, 7 templates, 15 MCP configs, 26 companion apps, 53 ecosystem entries, and more.**
+**The most comprehensive toolkit for Claude Code -- 135 agents, 35 curated skills (+400,000 via [SkillKit](https://agenstskills.com)), 42 commands, 176+ plugins, 20 hooks, 15 rules, 7 templates, 15 MCP configs, 27 companion apps, 53 ecosystem entries, and more.**
 
 <p align="center">
   <a href="https://trendshift.io/repositories/21839" target="_blank"><img src="https://trendshift.io/api/badge/repositories/21839" alt="rohitg00%2Fawesome-claude-code-toolkit | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
@@ -1058,6 +1058,7 @@ claude-code-toolkit/               850+ files
 | [cctally](https://github.com/omrikais/cctally) | new | Track Claude Code subscription usage as a weekly $-per-1% trend. Local web dashboard, terminal UI, forecasts, threshold alerts. Apache-2.0, zero telemetry. |
 | [claude-code-notifier](https://github.com/saiso/claude-code-notifier) | new | Native macOS notifier for Claude Code. Swift + UserNotifications, custom Heroicons-derived icon (SF Symbols–free), click-through to your IDE (VS Code, Cursor, Windsurf, JetBrains, iTerm2, Terminal) via bundle ID swap, per-event sound labels, hardened inputs (allowlists, length caps, control-character stripping). Universal binary (arm64 + x86_64), macOS 12+, MIT |
 | [ToutKit](https://github.com/toutkit/toutkit) | new | Desktop notebook for AI CLIs (Claude Code, Codex, Gemini). Pairs a sidebar of notes with a built-in terminal and an in-app webview that renders whatever the AI writes — each note is a self-contained folder with its own SQLite, key/value store, attached files, and scripts, so a note can grow from a static page into a sortable table, dashboard, or research tool. Local-first, AGPL-3.0 |
+| [areco](https://github.com/bb4407777/areco) | new | Remote cockpit for CLI coding agents -- drive Claude Code, Codex, Reasonix and other terminal AI agents from your browser or phone. Server-side pty sessions that survive lock/sleep and device switching, chat transcript view reading agent session files, multi-agent project rooms with @mention. TypeScript/Vue, npm, Apache-2.0 |
 
 ---
 


### PR DESCRIPTION
## What

Adds [areco](https://github.com/bb4407777/areco) to the **Companion Apps & GUIs** table.

## Why it belongs here

areco is a remote cockpit for CLI coding agents: it serves a web UI (browser or phone) that drives terminal AI agents such as Claude Code, Codex, and Reasonix running on your machine. Key features:

- Server-side persistent pty sessions -- agents keep running through screen lock, sleep, or device switching; resume the same session from any device
- Chat transcript view that reads each agent's on-disk session files into a clean bubble UI
- Project rooms: multiple agents in one group chat with @mention routing

Open source (Apache-2.0), TypeScript/Vue, installable via npm (`npm i -g areco`). Entry appended at the end of the table following the existing row format; companion app count in the header bumped 26 -> 27.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the toolkit overview to reflect 27 companion apps.
  * Added areco to the companion apps list, highlighting remote access to terminal AI tools and persistent project sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->