### PR TITLE
Add AgentBar to Companion Apps & GUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1058,6 +1058,7 @@ claude-code-toolkit/               850+ files
 | [cctally](https://github.com/omrikais/cctally) | new | Track Claude Code subscription usage as a weekly $-per-1% trend. Local web dashboard, terminal UI, forecasts, threshold alerts. Apache-2.0, zero telemetry. |
 | [claude-code-notifier](https://github.com/saiso/claude-code-notifier) | new | Native macOS notifier for Claude Code. Swift + UserNotifications, custom Heroicons-derived icon (SF Symbols–free), click-through to your IDE (VS Code, Cursor, Windsurf, JetBrains, iTerm2, Terminal) via bundle ID swap, per-event sound labels, hardened inputs (allowlists, length caps, control-character stripping). Universal binary (arm64 + x86_64), macOS 12+, MIT |
 | [ToutKit](https://github.com/toutkit/toutkit) | new | Desktop notebook for AI CLIs (Claude Code, Codex, Gemini). Pairs a sidebar of notes with a built-in terminal and an in-app webview that renders whatever the AI writes — each note is a self-contained folder with its own SQLite, key/value store, attached files, and scripts, so a note can grow from a static page into a sortable table, dashboard, or research tool. Local-first, AGPL-3.0 |
+| [AgentBar](https://github.com/michalstrnadel/AgentBar) | - | Native macOS menu bar app showing live status of Claude Code, Codex, and Copilot sessions via hooks, with one-click Allow / Always-allow / Deny of Claude Code permission prompts from the menu bar |
 
 ---
 


### PR DESCRIPTION
Adds [AgentBar](https://github.com/michalstrnadel/AgentBar) — a free, MIT-licensed native macOS menu bar app that shows live status of Claude Code (plus Codex/Copilot) sessions via hooks and lets you answer Claude Code permission prompts (Allow / Always allow with the suggested rule / Deny) directly from the menu bar. Swift/AppKit, no dependencies, universal binary, prebuilt releases + Homebrew tap. Docs include a full mapping of Claude Code hook events to app states.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added AgentBar to the list of companion apps, highlighting live session status and menu-bar controls for Claude Code permission prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->