### PR TITLE
Add autoqq to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1162,6 +1162,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [voidly-mcp-server](https://github.com/voidly-ai/mcp-server) | new | 116 tools for Claude Code covering censorship intelligence (19.6M OONI measurements, 126 countries), E2E encrypted agent-to-agent messaging, and agent payments. Install: `claude mcp add voidly -- npx -y @voidly/mcp-server` |
 | [systemprompt-template](https://github.com/systempromptio/systemprompt-template) | -- | Governance infrastructure for Claude Code. Single compiled Rust binary that authenticates, authorises, rate-limits, logs, and attributes costs for every AI interaction before it reaches a tool or database. Self-hosted, air-gap capable, MCP + A2A compatible. BSL-1.1 |
 | [llm-prices](https://github.com/benbencodes/llm-prices) | new | CLI + Python library + MCP server to look up and compare LLM API costs across 167 models from 23 providers (OpenAI, Anthropic, Google, xAI, DeepSeek, Groq, and more). Ask Claude "what's the cheapest model for 10k input + 2k output?" before making API calls. Zero deps, no API key. `pipx install git+https://github.com/benbencodes/llm-prices` |
+| [autoqq](https://github.com/Migiht/autoqq) | 2 | Linux CLI that schedules a `systemd` timer to ping Claude Code, Codex CLI, or opencode before you sit down, so the 5h rate-limit window is already fresh instead of starting when you open your laptop |
 
 ---
 


### PR DESCRIPTION
Adds [autoqq](https://github.com/Migiht/autoqq) — a small Linux CLI that schedules a `systemd` user timer to send a keep-alive ping to Claude Code, Codex CLI, or opencode before the workday starts, so the 5h rate-limit window is already fresh instead of only starting when the user opens their laptop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added autoqq to the Ecosystem section.
  - Described its Linux command-line functionality for scheduling rate-limit reminders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->