### PR TITLE
Add P2PA to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1162,6 +1162,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [voidly-mcp-server](https://github.com/voidly-ai/mcp-server) | new | 116 tools for Claude Code covering censorship intelligence (19.6M OONI measurements, 126 countries), E2E encrypted agent-to-agent messaging, and agent payments. Install: `claude mcp add voidly -- npx -y @voidly/mcp-server` |
 | [systemprompt-template](https://github.com/systempromptio/systemprompt-template) | -- | Governance infrastructure for Claude Code. Single compiled Rust binary that authenticates, authorises, rate-limits, logs, and attributes costs for every AI interaction before it reaches a tool or database. Self-hosted, air-gap capable, MCP + A2A compatible. BSL-1.1 |
 | [llm-prices](https://github.com/benbencodes/llm-prices) | new | CLI + Python library + MCP server to look up and compare LLM API costs across 167 models from 23 providers (OpenAI, Anthropic, Google, xAI, DeepSeek, Groq, and more). Ask Claude "what's the cheapest model for 10k input + 2k output?" before making API calls. Zero deps, no API key. `pipx install git+https://github.com/benbencodes/llm-prices` |
+| [P2PA](https://github.com/SanjoyDat1/P2PA) | new | Serverless P2P context sync for local AI agents (Cursor, Claude Code, Claude Desktop) over Hyperswarm. Ed25519 peer authentication (allowlist, no server trust), RFC 6902 JSON Patch diffs, versioned conflict detection, Markdown audit trail attributed per peer. `npm install -g p2pa` |
 
 ---
 


### PR DESCRIPTION
Adds [P2PA](https://github.com/SanjoyDat1/P2PA) to the Ecosystem table.

Serverless P2P context sync for local AI agents, built for exactly the Claude Code / Cursor multi-agent workflow this toolkit targets: shared JSON state synced over Hyperswarm (no server), ed25519 peer allowlist, RFC 6902 JSON Patch diffs, versioned conflict detection surfaced back to the agent, and a Markdown audit trail attributed per peer. MIT, TypeScript, `npm install -g p2pa`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added P2PA to the ecosystem overview.
  * Included a brief description of its serverless peer-to-peer context synchronization capabilities and installation instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->