### PR TITLE
Add claude-session-search to Companion Apps & GUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Claude Code Toolkit
 
-**The most comprehensive toolkit for Claude Code -- 135 agents, 35 curated skills (+400,000 via [SkillKit](https://agenstskills.com)), 42 commands, 176+ plugins, 20 hooks, 15 rules, 7 templates, 15 MCP configs, 26 companion apps, 53 ecosystem entries, and more.**
+**The most comprehensive toolkit for Claude Code -- 135 agents, 35 curated skills (+400,000 via [SkillKit](https://agenstskills.com)), 42 commands, 176+ plugins, 20 hooks, 15 rules, 7 templates, 15 MCP configs, 27 companion apps, 53 ecosystem entries, and more.**
 
 <p align="center">
   <a href="https://trendshift.io/repositories/21839" target="_blank"><img src="https://trendshift.io/api/badge/repositories/21839" alt="rohitg00%2Fawesome-claude-code-toolkit | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
@@ -1032,6 +1032,7 @@ claude-code-toolkit/               850+ files
 | [The Claude Protocol](https://github.com/AvivK5498/The-Claude-Protocol) | 149 | Enforcement layer wrapping Claude Code with 13 hooks -- blocks unsafe operations, enforces worktree isolation |
 | [Notch So Good](https://github.com/deepshal99/notch-so-good) | new | macOS notch-based session monitor with pixel-art companion, 13 animations, smart notifications, multi-session support |
 | [Anima](https://github.com/btangonan/anima) | new | Native macOS companion for Claude Code. Per-project ASCII familiars, nim token economy, cross-session watcher daemon. Tauri v2 + Rust, 4MB binary |
+| [claude-session-search](https://github.com/aleducode/cc-search) | new | Local full-text search for session history. Indexes prompts, responses, thinking, and tool output into SQLite FTS5; BM25 ranking, resume-from-search, zero dependencies, fully offline. `uvx claude-session-search` |
 | [crit](https://github.com/tomasz-tomczyk/crit) | 105 | Local browser UI for inline code review of any file or agent output; integrates with Claude Code via plan-hook to review and approve plans before execution, outputs structured .crit.json for agent consumption. |
 | [telegram-ai-bridge](https://github.com/AliceLJY/telegram-ai-bridge) | new | Run N parallel Claude Code sessions from your phone via Telegram. War Room mode, per-bot personas, A2A multi-agent collaboration, tool approval from phone. Supports Claude Code, Codex, and Gemini backends |
 | [Asynkor](https://github.com/asynkor/asynkor) | 3+ | Coordination layer for AI agent teams — file leasing, shared memory, cross-machine sync. One MCP server for Claude Code, Cursor, Windsurf, JetBrains. Open source client, hosted infrastructure |


### PR DESCRIPTION
Adds [claude-session-search](https://github.com/aleducode/cc-search) — a local full-text search engine for Claude Code session history.

- Indexes everything under `~/.claude/projects/` (prompts, responses, thinking, tool calls/outputs, subagent transcripts) into SQLite FTS5
- BM25 relevance ranking, project/role/date filters, and a resume button that copies `cd <project> && claude --resume <id>`
- Zero runtime dependencies (Python stdlib only), binds 127.0.0.1 only, fully offline
- `uvx claude-session-search` · MIT licensed · tests + CI

Also bumped the companion apps count in the header (26 → 27). Thanks for the toolkit!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the project tagline to reflect 27 companion apps.
  * Added `claude-session-search` to the Companion Apps & GUIs table, including its local session search capabilities and installation command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->