### PR TITLE
Add MulmoTerminal to Companion Apps & GUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1058,6 +1058,7 @@ claude-code-toolkit/               850+ files
 | [cctally](https://github.com/omrikais/cctally) | new | Track Claude Code subscription usage as a weekly $-per-1% trend. Local web dashboard, terminal UI, forecasts, threshold alerts. Apache-2.0, zero telemetry. |
 | [claude-code-notifier](https://github.com/saiso/claude-code-notifier) | new | Native macOS notifier for Claude Code. Swift + UserNotifications, custom Heroicons-derived icon (SF Symbols–free), click-through to your IDE (VS Code, Cursor, Windsurf, JetBrains, iTerm2, Terminal) via bundle ID swap, per-event sound labels, hardened inputs (allowlists, length caps, control-character stripping). Universal binary (arm64 + x86_64), macOS 12+, MIT |
 | [ToutKit](https://github.com/toutkit/toutkit) | new | Desktop notebook for AI CLIs (Claude Code, Codex, Gemini). Pairs a sidebar of notes with a built-in terminal and an in-app webview that renders whatever the AI writes — each note is a self-contained folder with its own SQLite, key/value store, attached files, and scripts, so a note can grow from a static page into a sortable table, dashboard, or research tool. Local-first, AGPL-3.0 |
+| [MulmoTerminal](https://github.com/receptron/mulmoterminal) | new | Browser terminal for running several Claude Code and Codex sessions at once. Grid of live PTYs colour-coded by state (working / needs input / done), cockpit roster with AI summaries and PR phase, tmux persistence, git worktree isolation with one-click PRs, per-session cost and context readouts, and Web Push to your phone. Local-only, MIT |
 
 ---
 


### PR DESCRIPTION
**Repo**: https://github.com/receptron/mulmoterminal · MIT · `npx mulmoterminal@latest`

Added one row to the end of **Companion Apps & GUIs**, matching the existing table format.

**What it is**

A browser terminal for running several Claude Code and Codex sessions at once. Each cell is a real PTY on your own machine streamed to xterm.js, and the grid colour-codes every session by state — working, blocked on input, done — so the one that needs you is visible without visiting each pane.

Beyond the grid: a cockpit roster that keeps every session as a text row (AI summary, your last prompt, latest reply, PR phase) while one is enlarged, tmux persistence across reloads and server restarts, git worktree isolation with commit / push / open-PR from the cell, per-session model / context / cost readouts, and Web Push to a phone with tap-to-answer.

Everything runs locally — your code, your keys, your existing `claude` CLI. Nothing is sent to a server we control.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added MulmoTerminal to the Companion Apps & GUIs list.
  * Included details about multi-session browser terminal support, session monitoring, persistence, isolation, usage metrics, and mobile notifications.
  * Noted that MulmoTerminal is local-only and MIT licensed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->