### PR TITLE
Add GoodMemory MCP config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1004,7 +1004,7 @@ claude-code-toolkit/               850+ files
     scripts/                       19 Node.js scripts
   rules/                           15 coding rules
   templates/claude-md/             7 CLAUDE.md templates
-  mcp-configs/                     8 server configurations
+  mcp-configs/                    17 server configurations
   contexts/                        5 context modes
   examples/                        3 walkthrough examples
   setup/                           Interactive installer

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Claude Code Toolkit
 
-**The most comprehensive toolkit for Claude Code -- 135 agents, 35 curated skills (+400,000 via [SkillKit](https://agenstskills.com)), 42 commands, 176+ plugins, 20 hooks, 15 rules, 7 templates, 15 MCP configs, 26 companion apps, 53 ecosystem entries, and more.**
+**The most comprehensive toolkit for Claude Code -- 135 agents, 35 curated skills (+400,000 via [SkillKit](https://agenstskills.com)), 42 commands, 176+ plugins, 20 hooks, 15 rules, 7 templates, 17 MCP configs, 26 companion apps, 53 ecosystem entries, and more.**
 
 <p align="center">
   <a href="https://trendshift.io/repositories/21839" target="_blank"><img src="https://trendshift.io/api/badge/repositories/21839" alt="rohitg00%2Fawesome-claude-code-toolkit | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
@@ -53,7 +53,7 @@ curl -fsSL https://raw.githubusercontent.com/rohitg00/awesome-claude-code-toolki
 - [Hooks](#hooks) (20 scripts)
 - [Rules](#rules) (15)
 - [Templates](#templates) (7)
-- [MCP Configs](#mcp-configs) (14)
+- [MCP Configs](#mcp-configs) (17)
 - [Contexts](#contexts) (5)
 - [Examples](#examples) (3)
 - [Companion Apps & GUIs](#companion-apps--guis)
@@ -921,7 +921,7 @@ cp templates/claude-md/standard.md CLAUDE.md
 
 ## MCP Configs
 
-Sixteen curated Model Context Protocol server configurations.
+Seventeen curated Model Context Protocol server configurations.
 
 | Config | File | Servers Included |
 |--------|------|-----------------|
@@ -941,6 +941,7 @@ Sixteen curated Model Context Protocol server configurations.
 | Finance | [`finance.json`](mcp-configs/finance.json) | Helium news/markets/options, Chart Library pattern intelligence, Fetch, Memory |
 | E-Commerce | [`ecommerce.json`](mcp-configs/ecommerce.json) | BuyWhere product search, price comparison, deal discovery across 1M+ products |
 | LLM Cost | [`llm-cost.json`](mcp-configs/llm-cost.json) | llm-prices: look up and compare API costs across 167 models from 23 providers before making calls |
+| GoodMemory | [`goodmemory.json`](mcp-configs/goodmemory.json) | [GoodMemory](https://github.com/hjqcan/GoodMemory) — local-first scoped memory with provenance, recall traces, read-only MCP by default, and opt-in governed writeback |
 
 ---
 

--- a/mcp-configs/goodmemory.json
+++ b/mcp-configs/goodmemory.json
@@ -3,7 +3,7 @@
     "goodmemory": {
       "command": "goodmemory-mcp",
       "args": ["--standalone", "--user-id", "YOUR_USER_ID"],
-      "description": "Local-first, scoped memory for Claude Code. Exposes recall context, provenance, traces, stats, and artifact inspection; read-only by default, with governed writeback opt-in via --allow-write. Install first: npm install -g goodmemory@0.7.1."
+      "description": "Local-first, scoped memory for Claude Code. Exposes recall context, provenance, traces, stats, and artifact inspection; read-only by default, with governed writeback opt-in via --allow-write. Install first: npm install -g goodmemory@0.7.2."
     }
   }
 }

--- a/mcp-configs/goodmemory.json
+++ b/mcp-configs/goodmemory.json
@@ -3,7 +3,7 @@
     "goodmemory": {
       "command": "goodmemory-mcp",
       "args": ["--standalone", "--user-id", "YOUR_USER_ID"],
-      "description": "Local-first, scoped memory for Claude Code. Exposes recall context, provenance, traces, stats, and artifact inspection; read-only by default, with governed writeback opt-in via --allow-write. Install first: npm install -g goodmemory@0.7.2."
+      "description": "Local-first, scoped memory for Claude Code. Exposes recall context, provenance, traces, stats, and artifact inspection; read-only by default, with governed writeback opt-in via --allow-write. Install first: npm install -g goodmemory."
     }
   }
 }

--- a/mcp-configs/goodmemory.json
+++ b/mcp-configs/goodmemory.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "goodmemory": {
+      "command": "goodmemory-mcp",
+      "args": ["--standalone", "--user-id", "YOUR_USER_ID"],
+      "description": "Local-first, scoped memory for Claude Code. Exposes recall context, provenance, traces, stats, and artifact inspection; read-only by default, with governed writeback opt-in via --allow-write. Install first: npm install -g goodmemory@0.7.1."
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add a standalone GoodMemory MCP configuration for Claude Code.
- Keep the example read-only by default, with governed writeback explicitly opt-in via `--allow-write`.
- Link the canonical project and document the pinned `goodmemory@0.7.2` install prerequisite.
- Correct the MCP config counts to 17 after adding the new file.

## Verification

- `jq empty mcp-configs/goodmemory.json`
- Parsed all 17 files under `mcp-configs/` with JSON decoding.
- Verified npm publishes `goodmemory@0.7.2` and the CLI requires `--standalone` plus `--user-id` for hostless operation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added GoodMemory as a supported MCP configuration.
  - Included standalone setup details, capabilities, installation guidance, and the required user ID placeholder for the GoodMemory integration.

- **Documentation**
  - Updated the toolkit overview to reflect the expanded total of 17 MCP configurations.
  - Corrected project structure documentation to accurately list all 17 server configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->