### PR TITLE
Add CC Harness to Companion Apps & GUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1058,7 +1058,7 @@ claude-code-toolkit/               850+ files
 | [cctally](https://github.com/omrikais/cctally) | new | Track Claude Code subscription usage as a weekly $-per-1% trend. Local web dashboard, terminal UI, forecasts, threshold alerts. Apache-2.0, zero telemetry. |
 | [claude-code-notifier](https://github.com/saiso/claude-code-notifier) | new | Native macOS notifier for Claude Code. Swift + UserNotifications, custom Heroicons-derived icon (SF Symbols–free), click-through to your IDE (VS Code, Cursor, Windsurf, JetBrains, iTerm2, Terminal) via bundle ID swap, per-event sound labels, hardened inputs (allowlists, length caps, control-character stripping). Universal binary (arm64 + x86_64), macOS 12+, MIT |
 | [ToutKit](https://github.com/toutkit/toutkit) | new | Desktop notebook for AI CLIs (Claude Code, Codex, Gemini). Pairs a sidebar of notes with a built-in terminal and an in-app webview that renders whatever the AI writes — each note is a self-contained folder with its own SQLite, key/value store, attached files, and scripts, so a note can grow from a static page into a sortable table, dashboard, or research tool. Local-first, AGPL-3.0 |
-| [CC Harness](https://github.com/lookfree/cc-harness) | 43 | Electron desktop workbench for Claude Code -- live subagent topology from session files, token cost breakdown by source with drill-down to the exact message, hook sandbox, configuration audit |
+| [CC Harness](https://github.com/lookfree/cc-harness) | new | Electron desktop workbench for Claude Code -- live subagent topology from session files, token cost breakdown by source with drill-down to the exact message, hook sandbox, configuration audit |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1058,6 +1058,7 @@ claude-code-toolkit/               850+ files
 | [cctally](https://github.com/omrikais/cctally) | new | Track Claude Code subscription usage as a weekly $-per-1% trend. Local web dashboard, terminal UI, forecasts, threshold alerts. Apache-2.0, zero telemetry. |
 | [claude-code-notifier](https://github.com/saiso/claude-code-notifier) | new | Native macOS notifier for Claude Code. Swift + UserNotifications, custom Heroicons-derived icon (SF Symbols–free), click-through to your IDE (VS Code, Cursor, Windsurf, JetBrains, iTerm2, Terminal) via bundle ID swap, per-event sound labels, hardened inputs (allowlists, length caps, control-character stripping). Universal binary (arm64 + x86_64), macOS 12+, MIT |
 | [ToutKit](https://github.com/toutkit/toutkit) | new | Desktop notebook for AI CLIs (Claude Code, Codex, Gemini). Pairs a sidebar of notes with a built-in terminal and an in-app webview that renders whatever the AI writes — each note is a self-contained folder with its own SQLite, key/value store, attached files, and scripts, so a note can grow from a static page into a sortable table, dashboard, or research tool. Local-first, AGPL-3.0 |
+| [CC Harness](https://github.com/lookfree/cc-harness) | 43 | Electron desktop workbench for Claude Code -- live subagent topology from session files, token cost breakdown by source with drill-down to the exact message, hook sandbox, configuration audit |
 
 ---
 


### PR DESCRIPTION
Adds CC Harness to the Companion Apps & GUIs table.

Open-source (MIT) Electron desktop workbench for Claude Code: reads session files locally, renders the subagent/workflow topology as a live graph, splits token cost by source (base / skills / subagents / MCP) with drill-down to the exact message that produced it, dry-runs hooks in a sandbox, and audits configuration for common cost and context issues.

Repo: https://github.com/lookfree/cc-harness

Note: the header count ("26 companion apps") is left unchanged — happy to bump it if you prefer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added CC Harness to the list of Companion Apps & GUIs.
  * Documented its workbench, subagent topology visualization, token-cost analysis, hook sandbox, and configuration auditing capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->