### PR TITLE
Add Skim to Companion Apps & GUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1058,6 +1058,7 @@ claude-code-toolkit/               850+ files
 | [cctally](https://github.com/omrikais/cctally) | new | Track Claude Code subscription usage as a weekly $-per-1% trend. Local web dashboard, terminal UI, forecasts, threshold alerts. Apache-2.0, zero telemetry. |
 | [claude-code-notifier](https://github.com/saiso/claude-code-notifier) | new | Native macOS notifier for Claude Code. Swift + UserNotifications, custom Heroicons-derived icon (SF Symbols–free), click-through to your IDE (VS Code, Cursor, Windsurf, JetBrains, iTerm2, Terminal) via bundle ID swap, per-event sound labels, hardened inputs (allowlists, length caps, control-character stripping). Universal binary (arm64 + x86_64), macOS 12+, MIT |
 | [ToutKit](https://github.com/toutkit/toutkit) | new | Desktop notebook for AI CLIs (Claude Code, Codex, Gemini). Pairs a sidebar of notes with a built-in terminal and an in-app webview that renders whatever the AI writes — each note is a self-contained folder with its own SQLite, key/value store, attached files, and scripts, so a note can grow from a static page into a sortable table, dashboard, or research tool. Local-first, AGPL-3.0 |
+| [Skim](https://skim.md) | - | Free, open-source browser extension (Chrome/Firefox) that live-renders the markdown files Claude Code writes (plans, reports) right in the browser, with a Copy-for-AI button to send the rendered doc back into your next prompt. |
 
 ---
 


### PR DESCRIPTION
Adding Skim, a free open-source Chrome/Firefox extension that live-renders the markdown Claude Code writes to disk (plans, reports), similar in spirit to ToutKit already listed here. MIT licensed, zero telemetry. https://skim.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added the Skim browser extension to the Companion Apps & GUIs table.
  * Documented live Markdown rendering and Copy-for-AI functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

![Skim rendering a markdown file with a table-of-contents sidebar](https://raw.githubusercontent.com/skim-md/skim/main/promo/png/01-hero.png)
