### PR TITLE
Add tintpad: macOS menu-bar launcher for coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Claude Code Toolkit
 
-**The most comprehensive toolkit for Claude Code -- 135 agents, 35 curated skills (+400,000 via [SkillKit](https://agenstskills.com)), 42 commands, 176+ plugins, 20 hooks, 15 rules, 7 templates, 15 MCP configs, 26 companion apps, 53 ecosystem entries, and more.**
+**The most comprehensive toolkit for Claude Code -- 135 agents, 35 curated skills (+400,000 via [SkillKit](https://agenstskills.com)), 42 commands, 176+ plugins, 20 hooks, 15 rules, 7 templates, 15 MCP configs, 27 companion apps, 53 ecosystem entries, and more.**
 
 <p align="center">
   <a href="https://trendshift.io/repositories/21839" target="_blank"><img src="https://trendshift.io/api/badge/repositories/21839" alt="rohitg00%2Fawesome-claude-code-toolkit | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
@@ -1058,6 +1058,7 @@ claude-code-toolkit/               850+ files
 | [cctally](https://github.com/omrikais/cctally) | new | Track Claude Code subscription usage as a weekly $-per-1% trend. Local web dashboard, terminal UI, forecasts, threshold alerts. Apache-2.0, zero telemetry. |
 | [claude-code-notifier](https://github.com/saiso/claude-code-notifier) | new | Native macOS notifier for Claude Code. Swift + UserNotifications, custom Heroicons-derived icon (SF Symbols–free), click-through to your IDE (VS Code, Cursor, Windsurf, JetBrains, iTerm2, Terminal) via bundle ID swap, per-event sound labels, hardened inputs (allowlists, length caps, control-character stripping). Universal binary (arm64 + x86_64), macOS 12+, MIT |
 | [ToutKit](https://github.com/toutkit/toutkit) | new | Desktop notebook for AI CLIs (Claude Code, Codex, Gemini). Pairs a sidebar of notes with a built-in terminal and an in-app webview that renders whatever the AI writes — each note is a self-contained folder with its own SQLite, key/value store, attached files, and scripts, so a note can grow from a static page into a sortable table, dashboard, or research tool. Local-first, AGPL-3.0 |
+| [Tintpad](https://github.com/sorkila/tintpad) | new | Native macOS menu-bar launcher for coding agents -- global hotkey opens a palette, fuzzy-find a git repo (frecency-ranked), pick agent (Claude Code, Codex, Gemini CLI) and run mode, and your own terminal opens at that repo with the agent running. Swift/SwiftUI, MIT, local-only |
 
 ---
 


### PR DESCRIPTION
Adds [Tintpad](https://github.com/sorkila/tintpad) to Companion Apps & GUIs, and bumps the companion-app count in the header to 27.

Tintpad is a free, open-source (MIT) native macOS menu-bar launcher: a global hotkey opens a palette, fuzzy-find a git repo (frecency-ranked), pick an agent (Claude Code, Codex, Gemini CLI) and run mode, and your own terminal opens at that repo with the agent already running. Local-only, no accounts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Tintpad to the list of companion apps.
  * Updated the toolkit total to 27 companion apps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->