### PR TITLE
Add qwen-audio-agent to Companion Apps & GUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1058,6 +1058,7 @@ claude-code-toolkit/               850+ files
 | [cctally](https://github.com/omrikais/cctally) | new | Track Claude Code subscription usage as a weekly $-per-1% trend. Local web dashboard, terminal UI, forecasts, threshold alerts. Apache-2.0, zero telemetry. |
 | [claude-code-notifier](https://github.com/saiso/claude-code-notifier) | new | Native macOS notifier for Claude Code. Swift + UserNotifications, custom Heroicons-derived icon (SF Symbols–free), click-through to your IDE (VS Code, Cursor, Windsurf, JetBrains, iTerm2, Terminal) via bundle ID swap, per-event sound labels, hardened inputs (allowlists, length caps, control-character stripping). Universal binary (arm64 + x86_64), macOS 12+, MIT |
 | [ToutKit](https://github.com/toutkit/toutkit) | new | Desktop notebook for AI CLIs (Claude Code, Codex, Gemini). Pairs a sidebar of notes with a built-in terminal and an in-app webview that renders whatever the AI writes — each note is a self-contained folder with its own SQLite, key/value store, attached files, and scripts, so a note can grow from a static page into a sortable table, dashboard, or research tool. Local-first, AGPL-3.0 |
+| [qwen-audio-agent](https://github.com/QwenAudio/qwen-audio-agent) | 1,900+ | Full-duplex voice interface for Claude Code and other ACP agents -- talk hands-free with barge-in, spoken permission prompts, async task results read back, and a local wake word (sherpa-onnx). macOS desktop app, terminal TUI, and web UI |
 
 ---
 


### PR DESCRIPTION
Adds one row to the **Companion Apps & GUIs** table, following the existing row format.

[qwen-audio-agent](https://github.com/QwenAudio/qwen-audio-agent) is a full-duplex voice interface for Claude Code (via claude-code-acp) and other ACP agents: hands-free conversations with barge-in, spoken permission prompts, async task results read back into the voice session, and a local wake word (sherpa-onnx KWS). Ships as a macOS desktop app, terminal TUI, and web UI. Apache-2.0.

Disclosure: I maintain this project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added `qwen-audio-agent` to the Companion Apps & GUIs list.
  * Noted its full-duplex voice interface for Claude Code and other compatible agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->