### PR TITLE
Add prompt-hook.sh (claude-session-tint) to Hook Scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -831,6 +831,7 @@ Twenty hook scripts covering all eight Claude Code lifecycle events. Place `hook
 | `stop-check.js` | Stop | Remind to run tests if code was modified |
 | `notification-log.js` | Notification | Log notifications for later review |
 | `prompt-check.js` | UserPromptSubmit | Detect vague prompts, suggest clarification |
+| [`prompt-hook.sh`](https://github.com/dotcomjack/claude-session-tint) | UserPromptSubmit | Run a command from the input box with zero model turns by returning `decision:"block"` with `suppressOriginalPrompt`; used to tag a terminal window with a project color |
 
 ### Related SDKs
 

--- a/README.md
+++ b/README.md
@@ -805,7 +805,7 @@ Then invoke in Claude Code:
 
 ## Hooks
 
-Twenty hook scripts covering all eight Claude Code lifecycle events. Place `hooks.json` in your `.claude/` directory.
+Twenty-one hook scripts covering all eight Claude Code lifecycle events. Place `hooks.json` in your `.claude/` directory.
 
 ### Hook Scripts
 
@@ -831,7 +831,7 @@ Twenty hook scripts covering all eight Claude Code lifecycle events. Place `hook
 | `stop-check.js` | Stop | Remind to run tests if code was modified |
 | `notification-log.js` | Notification | Log notifications for later review |
 | `prompt-check.js` | UserPromptSubmit | Detect vague prompts, suggest clarification |
-| [`prompt-hook.sh`](https://github.com/dotcomjack/claude-session-tint) | UserPromptSubmit | Run a command from the input box with zero model turns by returning `decision:"block"` with `suppressOriginalPrompt`; used to tag a terminal window with a project color |
+| [`prompt-hook.sh`](https://github.com/dotcomjack/claude-session-tint) | UserPromptSubmit | Run a command from the input box with zero model turns by returning `decision:"block"` with `suppressOriginalPrompt`, then exiting 2. Must be wired non-async, since an async hook returns after the prompt has already reached the model. Used to tag a terminal window with a project color |
 
 ### Related SDKs
 


### PR DESCRIPTION
Adds one row to the Hook Scripts table.

**What it is:** a `UserPromptSubmit` hook that runs a command typed in the Claude Code input box without invoking the model. It returns `decision:"block"` with `hookSpecificOutput.suppressOriginalPrompt`, so Claude Code never queries the model: no turn, no tokens, no assistant message in the transcript.

In the parent project it is used to tag a terminal window with a project color, but the hook itself is ~100 lines and is useful on its own as a pattern for any in-session command.

Two non-obvious details documented in the source, in case they are useful to others writing UserPromptSubmit hooks:
- the hook must be wired non-async, since an async hook returns after the prompt has already gone to the model and cannot gate it
- it exits 2 as well as printing the JSON, because there is an earlier success branch that can return before the blocking decision is applied

Repo: https://github.com/dotcomjack/claude-session-tint (MIT)

Formatted to match the existing external-link row (`smart-approve.py`). Happy to move it to Related SDKs or drop it if it is not a fit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the hooks documentation to list 21 available hook scripts.
  * Added documentation for the `prompt-hook.sh` UserPromptSubmit hook.
  * Clarified that input-box commands can run without model turns by blocking and suppressing the original prompt.
  * Documented non-async configuration requirements, exit status 2 behavior, and optional project-color terminal tagging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->