### PR TITLE
Add Parallel Search to the research MCP config

### DIFF
--- a/README.md
+++ b/README.md
@@ -932,7 +932,7 @@ Sixteen curated Model Context Protocol server configurations.
 | Frontend | [`frontend.json`](mcp-configs/frontend.json) | Puppeteer, Figma, Storybook |
 | Crypto / DeFi | [`crypto-defi.json`](mcp-configs/crypto-defi.json) | defi-mcp, Filesystem, Fetch, Memory |
 | DevOps | [`devops.json`](mcp-configs/devops.json) | AWS, Docker, GitHub, Terraform, Sentry |
-| Research | [`research.json`](mcp-configs/research.json) | BGPT scientific papers, Brave Search, Fetch, Memory, Filesystem |
+| Research | [`research.json`](mcp-configs/research.json) | BGPT scientific papers, Parallel web search, Brave Search, Fetch, Memory, Filesystem |
 | Observability | [`observability.json`](mcp-configs/observability.json) | Iris eval & observability for agent tracing, quality evaluation, and cost tracking |
 | Security | [`security.json`](mcp-configs/security.json) | Ghidra reverse engineering, Snyk vulnerability scanning |
 | Design | [`design.json`](mcp-configs/design.json) | Figma design context, Blender 3D automation |

--- a/mcp-configs/research.json
+++ b/mcp-configs/research.json
@@ -5,6 +5,11 @@
       "url": "https://mcp.bgpt.pro/sse",
       "description": "Search scientific papers with full-text experimental data via BGPT. 50 free searches, no API key needed."
     },
+    "parallel-search": {
+      "type": "http",
+      "url": "https://search.parallel.ai/mcp",
+      "description": "Search the web and retrieve page content for research. No API key needed."
+    },
     "fetch": {
       "command": "npx",
       "args": ["-y", "@modelcontextprotocol/server-fetch"],


### PR DESCRIPTION
## What changed

- add the hosted Parallel Search endpoint to `mcp-configs/research.json`
- update the README's Research config summary

This gives the existing research bundle a keyless HTTP option for web search and page retrieval. The other research servers and their configuration remain unchanged.

## Validation

- `python3 -m json.tool mcp-configs/research.json`
- checked the exact `parallel-search` JSON object with `jq`
- completed a live MCP handshake and confirmed `web_search` and `web_fetch`
- `git diff --check`

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Parallel web search to the Research MCP configuration.
  * Enables web search and page-content retrieval through the Parallel Search service without requiring an API key.
  * Updated the documentation to reflect the expanded research tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->