### PR TITLE
Add Companion TTS — reads Claude Code's output aloud (Windows)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,19 +27,19 @@
 **Plugin marketplace** (recommended):
 
 ```bash
-/plugin marketplace add rohitg00/awesome-claude-code-toolkit
+/plugin marketplace add rohitg00/awesome-claude-code-
 ```
 
 **Manual clone:**
 
 ```bash
-git clone https://github.com/rohitg00/awesome-claude-code-toolkit.git ~/.claude/plugins/claude-code-toolkit
+git clone https://github.com/rohitg00/awesome-claude-code-.git ~/.claude/plugins/claude-code-
 ```
 
 **One-liner:**
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/rohitg00/awesome-claude-code-toolkit/main/setup/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/rohitg00/awesome-claude-code-/main/setup/install.sh | bash
 ```
 
 ---
@@ -1058,6 +1058,8 @@ claude-code-toolkit/               850+ files
 | [cctally](https://github.com/omrikais/cctally) | new | Track Claude Code subscription usage as a weekly $-per-1% trend. Local web dashboard, terminal UI, forecasts, threshold alerts. Apache-2.0, zero telemetry. |
 | [claude-code-notifier](https://github.com/saiso/claude-code-notifier) | new | Native macOS notifier for Claude Code. Swift + UserNotifications, custom Heroicons-derived icon (SF Symbols–free), click-through to your IDE (VS Code, Cursor, Windsurf, JetBrains, iTerm2, Terminal) via bundle ID swap, per-event sound labels, hardened inputs (allowlists, length caps, control-character stripping). Universal binary (arm64 + x86_64), macOS 12+, MIT |
 | [ToutKit](https://github.com/toutkit/toutkit) | new | Desktop notebook for AI CLIs (Claude Code, Codex, Gemini). Pairs a sidebar of notes with a built-in terminal and an in-app webview that renders whatever the AI writes — each note is a self-contained folder with its own SQLite, key/value store, attached files, and scripts, so a note can grow from a static page into a sortable table, dashboard, or research tool. Local-first, AGPL-3.0 |
+
+- [**companion-tts**](https://github.com/kleenpulse/companion-tts) - A floating Windows companion that reads Claude Code's output aloud and speaks up when a session is waiting on you. Four TTS providers with automatic fallback, including offline Piper neural voices.
 
 ---
 


### PR DESCRIPTION
The list covers voice input for Claude Code — claude-code-voice (control, macOS), clui-cc (dictation, macOS), claude-code-voice-skill (phone) — and peon-ping for notification sounds. Nothing reads Claude's actual output aloud.

Companion TTS is a Tauri v2 desktop app that tails session transcripts and narrates them in real time, with a four-provider fallback chain (ElevenLabs → Mistral → offline Piper → Windows on-device) that works with no API key at all. GPL-3.0, Windows-only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Quick Install commands with shorter paths.
  * Added the `companion-tts` project to the companion applications list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->