### PR TITLE
Add MiniMax provider configuration

### DIFF
--- a/skills/llm-integration/SKILL.md
+++ b/skills/llm-integration/SKILL.md
@@ -30,6 +30,40 @@ async function generateResponse(
 }
 ```
 
+## MiniMax Provider Configuration
+
+The same SDK can call MiniMax through its Anthropic-compatible API. Select the
+endpoint for the account region and keep the API key in the environment.
+
+```typescript
+const MINIMAX_BASE_URLS = {
+  global: "https://api.minimax.io/anthropic",
+  china: "https://api.minimaxi.com/anthropic",
+} as const;
+
+type MiniMaxRegion = keyof typeof MINIMAX_BASE_URLS;
+
+function createMiniMaxClient(region: MiniMaxRegion = "global"): Anthropic {
+  const apiKey = process.env.MINIMAX_API_KEY;
+  if (!apiKey) throw new Error("MINIMAX_API_KEY is required");
+
+  return new Anthropic({
+    apiKey,
+    baseURL: MINIMAX_BASE_URLS[region],
+  });
+}
+
+const miniMaxClient = createMiniMaxClient(
+  process.env.MINIMAX_REGION === "china" ? "china" : "global"
+);
+
+const miniMaxResponse = await miniMaxClient.messages.create({
+  model: "MiniMax-M3",
+  max_tokens: 4096,
+  messages: [{ role: "user", content: "Design a resilient job queue" }],
+});
+```
+
 ## Streaming Responses
 
 ```typescript


### PR DESCRIPTION
Reason: The LLM integration skill lacks a MiniMax client configuration and model example.

- Add a region-aware client factory for the global and China endpoints.
- Read the API key from the environment and demonstrate a MiniMax-M3 request.

Checks:
- `git diff --check`
- `test "$(awk '/^```/{count++} END{print count % 2}' skills/llm-integration/SKILL.md)" = 0`
- Verified the example contains both regional endpoints, `MINIMAX_API_KEY`, and `MiniMax-M3`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added MiniMax AI provider configuration.
  - Supports global and China regional endpoints.
  - Uses the `MINIMAX_REGION` setting to select the appropriate service region.
  - Includes a sample request using the MiniMax-M3 model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->