### PR TITLE
Add cicada-husk to All Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Over 176 production-ready plugins that extend Claude Code with domain-specific c
 
 | Plugin | Description |
 |--------|-------------|
+| [cicada-husk](https://github.com/blazephoenixxyz-crypto/cicada-husk) | Token-lean operating discipline for Claude Code: reads code by symbol instead of by whole file, cites prior findings by name, doses effort per task, never polls, and budgets every sub-agent by risk. Applies its own doctrine to itself -- knowledge ships as documentation, so the runtime surface is two commands, one script and a ~25-token session banner: ~0 tokens per turn. Fully read-only, MIT |
 | [agento-patronum](https://github.com/emaarco/agento-patronum) | Protects sensitive files, credentials, and shell commands from unintended AI access via Claude Code hooks. Unlike settings.json deny rules, hooks are an enforcement layer you own and can verify. Ships with defaults for .env files, SSH keys, AWS credentials, and kubeconfig. |
 | [skills-janitor](https://github.com/khendzel/skills-janitor) | Audit, deduplicate, check, fix, and track usage of your Claude Code skills. 9 slash commands, zero dependencies |
 | [great_cto](https://github.com/avelikiy/great_cto) | Full SDLC pipeline plugin with 7 agents (tech-lead, senior-dev, qa-engineer, security-officer, devops, l3-support, project-auditor), 12-angle code review, 10 project archetypes, 13 compliance frameworks (SOC2/HIPAA/PCI-DSS/GDPR/ISO 27001), two-gate approval flow. Opus 4.7 advisor escalation, file-based, MIT |


### PR DESCRIPTION
Adds [cicada-husk](https://github.com/blazephoenixxyz-crypto/cicada-husk) to the **All Plugins** table.

A token-lean operating discipline for Claude Code: read code by symbol instead of by whole file, cite prior findings by name rather than re-deriving them, dose effort to the task, never poll in a loop, and budget every sub-agent by risk.

It applies its own doctrine to itself. A plugin is billed only where bytes enter the model's context, so the knowledge ships as documentation (free at runtime) and the runtime surface stays deliberately small: two commands, one portable shell script, one ~25-token session banner — **~0 tokens per turn**, with no per-turn spikes by construction.

Fully **read-only**: no daemon, no background process, nothing that can touch files, memory or state. MIT, current release v0.5.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the `cicada-husk` plugin to the all-plugins catalog, including its repository link and description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->