### PR TITLE
Add claude-threads

### DIFF
--- a/README.md
+++ b/README.md
@@ -1058,6 +1058,7 @@ claude-code-toolkit/               850+ files
 | [cctally](https://github.com/omrikais/cctally) | new | Track Claude Code subscription usage as a weekly $-per-1% trend. Local web dashboard, terminal UI, forecasts, threshold alerts. Apache-2.0, zero telemetry. |
 | [claude-code-notifier](https://github.com/saiso/claude-code-notifier) | new | Native macOS notifier for Claude Code. Swift + UserNotifications, custom Heroicons-derived icon (SF Symbols–free), click-through to your IDE (VS Code, Cursor, Windsurf, JetBrains, iTerm2, Terminal) via bundle ID swap, per-event sound labels, hardened inputs (allowlists, length caps, control-character stripping). Universal binary (arm64 + x86_64), macOS 12+, MIT |
 | [ToutKit](https://github.com/toutkit/toutkit) | new | Desktop notebook for AI CLIs (Claude Code, Codex, Gemini). Pairs a sidebar of notes with a built-in terminal and an in-app webview that renders whatever the AI writes — each note is a self-contained folder with its own SQLite, key/value store, attached files, and scripts, so a note can grow from a static page into a sortable table, dashboard, or research tool. Local-first, AGPL-3.0 |
+| [claude-threads](https://github.com/anneschuth/claude-threads) | 38 | Slack and Mattermost bot that streams Claude Code sessions into threads. Teammates reply to steer, approve tool use with emoji reactions, one session per thread with resume after restart |
 
 ---
 


### PR DESCRIPTION
Adds claude-threads, a bot that runs Claude Code sessions in Slack or Mattermost threads so a team can follow along and approve tool use with emoji reactions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added `claude-threads` to the Companion Apps & GUIs table.
  * Documented its Slack and Mattermost integration for streaming and controlling Claude Code sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->