### PR TITLE
Add dsh-plugin-cc — DeepSeek Harness bridge for Claude Code

### DIFF
--- a/plugins/dsh-plugin-cc/.claude-plugin/plugin.json
+++ b/plugins/dsh-plugin-cc/.claude-plugin/plugin.json
@@ -1,0 +1,10 @@
+{
+  "name": "dsh-plugin-cc",
+  "version": "1.0.0",
+  "description": "Bridge Claude Code to the DeepSeek Harness agent for review, critique, delegation, and resumable sessions",
+  "homepage": "https://github.com/cpj-dev/dsh-plugin-cc",
+  "repository": "https://github.com/cpj-dev/dsh-plugin-cc",
+  "license": "MIT",
+  "keywords": ["deepseek", "dsh", "code-review", "delegation", "bridge"],
+  "commands": ["commands/install.md"]
+}

--- a/plugins/dsh-plugin-cc/README.md
+++ b/plugins/dsh-plugin-cc/README.md
@@ -1,0 +1,23 @@
+# dsh-plugin-cc
+
+Claude Code marketplace bridging to the [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness) (`dsh`) agent.
+
+## Install
+
+```bash
+/plugin marketplace add cpj-dev/dsh-plugin-cc
+/plugin install dsh@deepseek-dsh
+/dsh:setup
+```
+
+## Commands
+
+| Command | Purpose |
+|---|---|
+| `/dsh:check` | Readiness probe |
+| `/dsh:review` | Read-only review of local changes |
+| `/dsh:critique` | Adversarial design critique |
+| `/dsh:delegate <task>` | Background delegation |
+| `/dsh:run <task>` | One-shot or resumable dsh session |
+
+Source: https://github.com/cpj-dev/dsh-plugin-cc

--- a/plugins/dsh-plugin-cc/commands/install.md
+++ b/plugins/dsh-plugin-cc/commands/install.md
@@ -1,0 +1,20 @@
+# Install dsh-plugin-cc
+
+This toolkit entry points at the live marketplace. Install it from the source repo rather than copying the runtime into this toolkit:
+
+```bash
+/plugin marketplace add cpj-dev/dsh-plugin-cc
+/plugin install dsh@deepseek-dsh
+```
+
+Then run `/dsh:setup` once (needs `DEEPSEEK_API_KEY`, Node >= 20, and a DeepSeek Harness source build).
+
+After that, in any git repository:
+
+- `/dsh:check` — readiness probe
+- `/dsh:review` — read-only review of local changes
+- `/dsh:critique` — adversarial design critique
+- `/dsh:delegate <task>` — background delegation
+- `/dsh:run <task>` — one-shot or resumable dsh session
+
+Repo: https://github.com/cpj-dev/dsh-plugin-cc


### PR DESCRIPTION
## What this adds

Adds [dsh-plugin-cc](https://github.com/cpj-dev/dsh-plugin-cc) — a Claude Code marketplace that bridges to the DeepSeek Harness (`dsh`) agent for review, critique, delegation, background runs, and resumable multi-turn sessions.

## Plugin files

Following CONTRIBUTING.md, the plugin lives at `plugins/dsh-plugin-cc/`:

- `.claude-plugin/plugin.json` — manifest with homepage/repository pointing at the live marketplace
- `commands/install.md` — install instructions (`/plugin marketplace add cpj-dev/dsh-plugin-cc`)
- `README.md` — command summary

The runtime stays in the source repo (Node bridge + tests). Users install from that marketplace rather than copying the harness build into this toolkit.

## README table row (All Plugins, after `double-check`)

Please also add this row to the All Plugins table so the listing is discoverable:

```markdown
| [dsh-plugin-cc](https://github.com/cpj-dev/dsh-plugin-cc) | Claude Code marketplace bridging to the DeepSeek Harness (`dsh`) agent: review, critique, delegation, background runs, and resumable multi-turn sessions. Install: `/plugin marketplace add cpj-dev/dsh-plugin-cc` then `/plugin install dsh@deepseek-dsh` |
```

## Install

```bash
/plugin marketplace add cpj-dev/dsh-plugin-cc
/plugin install dsh@deepseek-dsh
```

Public MIT repo. No telemetry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `dsh-plugin-cc` Claude Code marketplace plugin.
  * Included plugin metadata, licensing details, keywords, and repository information.

* **Documentation**
  * Added installation and setup instructions.
  * Documented available DSH commands and marketplace installation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->