### PR TITLE
Add VocalCode (push-to-talk voice input for Claude Code) to Companion Apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1027,6 +1027,7 @@ claude-code-toolkit/               850+ files
 | [parallel-code](https://github.com/johannesjo/parallel-code) | 370+ | Run Claude Code, Codex, and Gemini side by side -- each in its own git worktree |
 | [Bernstein](https://github.com/sipyourdrink-ltd/bernstein) | 288 | Python orchestrator for 40+ CLI coding agents (Claude Code, Codex, Gemini CLI). Git worktree isolation, MCP server mode, HMAC audit trail. Plan-driven, deterministic. Apache-2.0 |
 | [Poirot](https://github.com/LeonardoCardoso/Poirot) | 96 | macOS app for browsing Claude Code sessions, viewing diffs, and re-running commands. Reads local transcripts, runs offline |
+| [VocalCode](https://vocalcode.app) | - | Push-to-talk voice input for driving Claude Code by voice -- on-device speech recognition (CPU-only, works offline), spelled acronyms collapse ("m c p" -> MCP), user dictionary, send-to-agent binding. Bilingual Chinese-English + 25 European languages. Windows + Apple Silicon macOS, one-time purchase (USD 4.99) with 30-day free trial |
 | [TokenEater](https://github.com/AThevon/TokenEater) | 179 | Native macOS menu bar app for monitoring Claude AI usage limits and watching coding sessions live |
 | [Claw](https://github.com/jamesrochabrun/Claw) | 86 | Native macOS app wrapping Claude Code SDK in Swift. Plan Mode, MCP Integration, Custom System Prompts |
 | [The Claude Protocol](https://github.com/AvivK5498/The-Claude-Protocol) | 149 | Enforcement layer wrapping Claude Code with 13 hooks -- blocks unsafe operations, enforces worktree isolation |


### PR DESCRIPTION
## What

Adds VocalCode to the Companion Apps & GUIs table: push-to-talk voice input for driving Claude Code by voice.

## Why it fits this list

- Built specifically for prompting coding agents: spelled acronyms collapse ("m c p" -> MCP), a user dictionary for project jargon, and a send binding so a whole prompt is hold-speak-release-send
- Speech recognition runs entirely on-device (CPU-only, works offline) - nothing dictated to Claude Code transits a third-party cloud
- Bilingual Chinese-English model plus 25 European languages
- Windows 10/11 + Apple Silicon macOS, signed installers

## Transparency

I am the developer. It is a paid product (USD 4.99 one-time) with a 30-day full trial, no card required - stated in the row so readers know before clicking. Happy to adjust wording or move the row wherever you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added VocalCode to the Companion Apps & GUIs list.
  * Documented its voice-input capabilities, supported platforms and languages, pricing, and trial availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->