### PR TITLE
Add Aeon to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1162,6 +1162,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [voidly-mcp-server](https://github.com/voidly-ai/mcp-server) | new | 116 tools for Claude Code covering censorship intelligence (19.6M OONI measurements, 126 countries), E2E encrypted agent-to-agent messaging, and agent payments. Install: `claude mcp add voidly -- npx -y @voidly/mcp-server` |
 | [systemprompt-template](https://github.com/systempromptio/systemprompt-template) | -- | Governance infrastructure for Claude Code. Single compiled Rust binary that authenticates, authorises, rate-limits, logs, and attributes costs for every AI interaction before it reaches a tool or database. Self-hosted, air-gap capable, MCP + A2A compatible. BSL-1.1 |
 | [llm-prices](https://github.com/benbencodes/llm-prices) | new | CLI + Python library + MCP server to look up and compare LLM API costs across 167 models from 23 providers (OpenAI, Anthropic, Google, xAI, DeepSeek, Groq, and more). Ask Claude "what's the cheapest model for 10k input + 2k output?" before making API calls. Zero deps, no API key. `pipx install git+https://github.com/benbencodes/llm-prices` |
+| [Aeon](https://github.com/aeonfun/aeon) | 666 | Autonomous agent framework that runs entirely inside GitHub Actions. Cron-scheduled Markdown skills self-heal and file repair PRs, spawn a fleet of clones, and ship 70+ Agent Skills across six coding-agent harnesses (Claude Code, Grok, Codex, Pi, Vibe, Kimi). MIT |
 
 ---
 


### PR DESCRIPTION
Adding **[Aeon](https://github.com/aeonfun/aeon)** to the **Ecosystem** table.

Aeon is an autonomous agent framework that runs entirely inside GitHub Actions. Cron-scheduled Markdown skills self-heal (a health skill detects failures and a repair skill fixes them by PR), spawn a fleet of clones, and ship 70+ Agent Skills across six coding-agent harnesses (Claude Code default, plus Grok, Codex, Pi, Vibe, Kimi). It is also MCP-native and exposes its own skills as an MCP server.

- Repo: https://github.com/aeonfun/aeon
- License: MIT · 666 stars · actively maintained (daily commits)
- Fits the Ecosystem table alongside the other Markdown-first multi-agent frameworks and autonomous-delivery projects already listed (paco-framework, GAAI Framework, Wiggum CLI).

Appended as a new table row, single entry, columns match the existing rows (Name | Stars | Description).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Aeon to the ecosystem listings, including its repository link, popularity, capabilities, supported coding-agent harnesses, and license.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->