### PR TITLE
Add 500k.io Skills Bank to Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1190,6 +1190,7 @@ Tutorials, guides, and deep-dives on Claude Code.
 | [Dispatch & Remote Control](https://claude.com/blog/dispatch-and-computer-use) | Blog | Run Claude Code from phone/web, schedule recurring tasks, remote session control |
 | [Claude Code Cheat Sheet](https://cc.storyfox.cz/) | Reference | One-page printable reference, auto-updated daily, 4 languages |
 | [Multi-Agent Orchestra](https://addyosmani.com/blog/code-agent-orchestra/) | Blog | Addy Osmani's survey of multi-agent coding patterns |
+| [500k.io Skills Bank](https://500k.io/skills) | Directory | Searchable index of 638+ Claude, Claude Code and MCP skills — install command, compatibility matrix and popularity signals per entry, refreshed weekly |
 
 ## Related Awesome Lists
 


### PR DESCRIPTION
Adding the 500k.io Skills Bank to the Resources table — a searchable directory of 638+ skills for Claude, Claude Code, Cowork and MCP-compatible agents, refreshed weekly from GitHub, Anthropic and community sources.

Each entry ships the install command, a compatibility matrix, and popularity signals. Free, no signup required.

Disclosure: I maintain it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the 500k.io Skills Bank to the Resources section.
  * The directory provides searchable Claude, Claude Code, and MCP skills.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->