### PR TITLE
docs: add UIZZE anti-ui-slop community skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ curl -fsSL https://raw.githubusercontent.com/rohitg00/awesome-claude-code-toolki
 
 - [Plugins](#plugins) (176+)
 - [Agents](#agents) (135)
-- [Skills](#skills) (35 curated + 28 community)
+- [Skills](#skills) (35 curated + 29 community)
 - [Commands](#commands) (42)
 - [Hooks](#hooks) (20 scripts)
 - [Rules](#rules) (15)
@@ -589,6 +589,7 @@ Thirty-five curated skill modules included in this repo, with access to **400,00
 | [deep-dive](https://github.com/kimsb2429/deep-dive-skill) | `git clone https://github.com/kimsb2429/deep-dive-skill && cp -r deep-dive-skill/deep-dive ~/.claude/skills/` | DAG-based deep research — breaks questions into a dependency graph, runs parallel subagents, identifies gaps, writes a sourced report. Single markdown file, no external APIs or MCP servers. |
 | [Reepl - LinkedIn Content Creation](https://github.com/reepl-io/skills) | `npx skillkit@latest install reepl-io/skills` | 18 tools for LinkedIn content management: drafts, publishing, scheduling, voice profiles, contacts, collections, templates, and AI image generation |
 | [avoid-ai-writing](https://github.com/conorbronsdon/avoid-ai-writing) | `git clone https://github.com/conorbronsdon/avoid-ai-writing ~/.claude/skills/avoid-ai-writing` | AI writing pattern detection and rewriting (21 categories, 43 replacements) |
+| [anti-ui-slop](https://github.com/uizze/uizze/tree/main/skills/anti-ui-slop) | `npx skills add uizze/uizze --skill anti-ui-slop` | Free MIT skill for UI-specific critique: checks loading, empty, error, responsive, and accessibility states, then runs a hard finish gate. The optional UIZZE workflow previews real web and iOS references from 800,000+ screens without an account and adds live search, validation, and audits. |
 | [CCM](https://github.com/dr5hn/ccm) | `npx skills add dr5hn/ccm@ccm` | Multi-account management, session cleanup, health checks, environment snapshots, permissions audit for Claude Code |
 | [cc-inspect](https://github.com/howardpen9/cc-inspect) | `git clone https://github.com/howardpen9/cc-inspect ~/.claude/skills/cc-inspect` | Inspect all installed Claude Code skills, plugins, MCP servers, commands, and hooks in a browser dashboard. Scope-aware (user/project/local), zero dependencies (pure bash + python3), generates self-contained HTML |
 | [Edison](https://github.com/kilnside/edison) | `git clone https://github.com/kilnside/edison ~/.claude/skills/edison` | Design decision skill — the phase between brainstorming and building. Research-first progressive deepening with self-executing specs. Three modes: Check, Explore, Audit |

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ curl -fsSL https://raw.githubusercontent.com/rohitg00/awesome-claude-code-toolki
 
 - [Plugins](#plugins) (176+)
 - [Agents](#agents) (135)
-- [Skills](#skills) (35 curated + 29 community)
+- [Skills](#skills) (35 curated + 88 community)
 - [Commands](#commands) (42)
 - [Hooks](#hooks) (20 scripts)
 - [Rules](#rules) (15)
@@ -589,7 +589,7 @@ Thirty-five curated skill modules included in this repo, with access to **400,00
 | [deep-dive](https://github.com/kimsb2429/deep-dive-skill) | `git clone https://github.com/kimsb2429/deep-dive-skill && cp -r deep-dive-skill/deep-dive ~/.claude/skills/` | DAG-based deep research — breaks questions into a dependency graph, runs parallel subagents, identifies gaps, writes a sourced report. Single markdown file, no external APIs or MCP servers. |
 | [Reepl - LinkedIn Content Creation](https://github.com/reepl-io/skills) | `npx skillkit@latest install reepl-io/skills` | 18 tools for LinkedIn content management: drafts, publishing, scheduling, voice profiles, contacts, collections, templates, and AI image generation |
 | [avoid-ai-writing](https://github.com/conorbronsdon/avoid-ai-writing) | `git clone https://github.com/conorbronsdon/avoid-ai-writing ~/.claude/skills/avoid-ai-writing` | AI writing pattern detection and rewriting (21 categories, 43 replacements) |
-| [anti-ui-slop](https://github.com/uizze/uizze/tree/main/skills/anti-ui-slop) | `npx skills add uizze/uizze --skill anti-ui-slop` | Free MIT skill for UI-specific critique: checks loading, empty, error, responsive, and accessibility states, then runs a hard finish gate. The optional UIZZE workflow previews real web and iOS references from 800,000+ screens without an account and adds live search, validation, and audits. |
+| [anti-ui-slop](https://github.com/uizze/uizze/tree/main/skills/anti-ui-slop) | `npx skills add https://uizze.com --skill anti-ui-slop` | Free MIT skill for UI-specific critique: checks loading, empty, error, responsive, and accessibility states, then runs a hard finish gate without an account. Optional full UIZZE adds live search across 800,000+ real web and iOS screens, design contracts, validation, audits, and rendered critique. |
 | [CCM](https://github.com/dr5hn/ccm) | `npx skills add dr5hn/ccm@ccm` | Multi-account management, session cleanup, health checks, environment snapshots, permissions audit for Claude Code |
 | [cc-inspect](https://github.com/howardpen9/cc-inspect) | `git clone https://github.com/howardpen9/cc-inspect ~/.claude/skills/cc-inspect` | Inspect all installed Claude Code skills, plugins, MCP servers, commands, and hooks in a browser dashboard. Scope-aware (user/project/local), zero dependencies (pure bash + python3), generates self-contained HTML |
 | [Edison](https://github.com/kilnside/edison) | `git clone https://github.com/kilnside/edison ~/.claude/skills/edison` | Design decision skill — the phase between brainstorming and building. Research-first progressive deepening with self-executing specs. Three modes: Check, Explore, Audit |


### PR DESCRIPTION
## Summary

- add UIZZE's free MIT `anti-ui-slop` skill to the Community Skills table
- include the canonical `npx skills add uizze/uizze --skill anti-ui-slop` install command
- describe the free skill first and keep the optional 800,000+ screen workflow separate
- update the community skill count in the table of contents

UIZZE is a direct fit for the toolkit's existing UI, frontend, and skill audience. The entry links to the canonical skill source and does not copy vendor metadata or require an account.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the community skills table of contents to include 88 skills.
  * Added the `anti-ui-slop` community skill, including installation instructions and a description of its UI critique capabilities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->