### PR TITLE
Add Claude Code Cheat Sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1189,6 +1189,7 @@ Tutorials, guides, and deep-dives on Claude Code.
 | [Computer Use from CLI](https://code.claude.com/docs/en/computer-use) | Docs | Let Claude control your desktop — open apps, click, type, screenshot. macOS, Pro/Max, v2.1.85+. Per-app approval, tiered access, Esc abort |
 | [Dispatch & Remote Control](https://claude.com/blog/dispatch-and-computer-use) | Blog | Run Claude Code from phone/web, schedule recurring tasks, remote session control |
 | [Claude Code Cheat Sheet](https://cc.storyfox.cz/) | Reference | One-page printable reference, auto-updated daily, 4 languages |
+| [Claude Code Cheat Sheet](https://coding-cheatsheet.com/) | Reference | Searchable quick reference for Claude Code commands, configuration, MCP servers, workflows, shortcuts, and common errors |
 | [Multi-Agent Orchestra](https://addyosmani.com/blog/code-agent-orchestra/) | Blog | Addy Osmani's survey of multi-agent coding patterns |
 
 ## Related Awesome Lists


### PR DESCRIPTION
## Summary

- Add [Claude Code Cheat Sheet](https://coding-cheatsheet.com/) to the Resources table.
- Describe it as a searchable reference for Claude Code commands, configuration, MCP servers, workflows, shortcuts, and common errors.

## Validation

- Verified the linked site returns the Vercel-hosted page.
- Ran `git diff --check`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Claude Code Cheat Sheet resource link to coding-cheatsheet.com.
  * Added a description highlighting searchable Claude Code references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->