### PR TITLE
Add awesome-claude-code-hooks to related lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -1206,6 +1206,7 @@ Tutorials, guides, and deep-dives on Claude Code.
 | [awesome-claude-design](https://github.com/rohitg00/awesome-claude-design) | ![Stars](https://img.shields.io/github/stars/rohitg00/awesome-claude-design?style=flat-square&label=) | DESIGN.md files grouped by aesthetic family (editorial, terminal, warm, data-dense, cinematic, playful, glass, brutalist, indie) + remix recipes + prompt packs for Claude Design (Anthropic Labs) |
 | [ai-skill](https://github.com/anomalyco/ai-skill) | - | AI skill discovery and management system - helps users find, evaluate, install and manage agent skills, tools, plugins and extensions |
 | [Awesome AI Startups](https://github.com/nowork-studio/awesome-ai-startups) | new | Curated directory of ~440 indie-built AI products (bootstrapped, pre-seed, angel-funded) across 18 categories — AI agents, coding tools, marketing, audio/voice, image/design, video, and more |
+| [awesome-claude-code-hooks](https://github.com/loqimean/awesome-claude-code-hooks) | new | Curated list of Claude Code hook implementations and guides. |
 
 ## Contributing
 


### PR DESCRIPTION
Adds a link to [awesome-claude-code-hooks](https://github.com/loqimean/awesome-claude-code-hooks) in the Related Awesome Lists section. It is a curated list of Claude Code hook implementations and guides, which fits alongside the other hooks in this repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a related resource featuring curated Claude Code hook implementations and guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->