### PR TITLE
Add WebMCP Kit to All Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ Over 176 production-ready plugins that extend Claude Code with domain-specific c
 | [VibeGuard](https://github.com/majiayu000/vibeguard) | Stop AI from hallucinating code. 88 rules + 13 hooks + 14 agents for real-time interception and static scanning across 5 languages |
 | [visual-regression](plugins/visual-regression/) | Visual regression testing with screenshot comparison |
 | [wshobson/agents](https://github.com/wshobson/agents) | 112 specialized agents, 16 multi-agent workflow orchestrators, 146 skills, 79 tools in 72 focused plugins. 31,300+ stars |
+| [WebMCP Kit](https://github.com/nekuda-ai/webmcp-kit) | Coding-agent plugin that maps a web app's user journeys in a visual Explorer, proposes WebMCP tools for approval, implements them through the app's own logic, and verifies each tool in a real browser. |
 | [web-dev](plugins/web-dev/) | Full-stack web development with app scaffolding and page generation |
 | [whatsapp-claude-plugin](https://github.com/Rich627/whatsapp-claude-plugin) | WhatsApp channel plugin for Claude Code -- connects as a linked device via Baileys v7 with bidirectional messaging, full media support, voice transcription, permission relay, and access control |
 | [workflow-optimizer](plugins/workflow-optimizer/) | Development workflow analysis and optimization recommendations |


### PR DESCRIPTION
## Summary

Add WebMCP Kit to All Plugins and highlight its visual Explorer and real-browser verification workflow.

## Fit

- **Real use case:** turns an existing website or web app into an agent-ready product by implementing WebMCP tools through the app's own logic instead of scraping the page.
- **Not duplicative:** a repository-wide search found no existing WebMCP implementation plugin listing.
- **Tested:** the plugin ships automated tests, its focused public test set passes 43 checks, and its workflow verifies each generated tool in a real browser before reporting it as verified.

## Validation

- `git diff --check`
- WebMCP Kit repository link responds successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added WebMCP Kit to the README’s All Plugins catalog.
  * Included a repository link and an overview of visual user-journey mapping, WebMCP tool creation, and browser-based verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->