### PR TITLE
Add dotagents to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1067,6 +1067,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 
 | Name | Stars | Description |
 |------|-------|-------------|
+| [dotagents](https://github.com/yourconscience/dotagents) | 3 | One `~/.agents` repo syncing skills, MCP servers, hooks, agent roles, root instructions, and memory tooling natively into Claude Code, Codex, OMP/Pi, OpenCode, Droid, and Hermes. Commit-pinned, audited external skills; brew + npm. MIT. |
 | [claude-mem](https://github.com/thedotmack/claude-mem) | 35,900+ | Auto-captures everything Claude does, compresses with AI, injects context into future sessions. #1 trending GitHub Feb 2026 |
 | [wshobson/agents](https://github.com/wshobson/agents) | 31,300+ | 112 specialized agents, 16 orchestrators, 146 skills, 79 tools in 72 focused plugins |
 | [oh-my-claudecode](https://github.com/Yeachan-Heo/oh-my-claudecode) | 9,900+ | Teams-first multi-agent orchestration with 19 specialized agents and 28 skills |


### PR DESCRIPTION
Adds [dotagents](https://github.com/yourconscience/dotagents) — a Go CLI that keeps one `~/.agents` repo (skills, MCP servers, hooks, agent roles, root instructions, memory tooling) synced natively into Claude Code, Codex, OMP/Pi, OpenCode, Droid, and Hermes, with commit-pinned and audited external skills. MIT, installable via Homebrew tap and npm (`@your_conscience/dotagents`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added `dotagents` to the README’s Ecosystem directory, including its repository link, star count, and description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->