### PR TITLE
Add Concord MCP to the Claude Code ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1067,6 +1067,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 
 | Name | Stars | Description |
 |------|-------|-------------|
+| [Concord MCP](https://github.com/Get-Concord-AI/concord-mcp) | 240+ | Cross-harness coordination for Claude Code, Codex, Cursor, Gemini CLI, and Grok Build. Agents claim work, detect edit overlap, exchange durable messages, transfer ownership, and hand off review evidence through five MCP workflow tools. MIT, npm: `@concord-ai/concord-mcp` |
 | [claude-mem](https://github.com/thedotmack/claude-mem) | 35,900+ | Auto-captures everything Claude does, compresses with AI, injects context into future sessions. #1 trending GitHub Feb 2026 |
 | [wshobson/agents](https://github.com/wshobson/agents) | 31,300+ | 112 specialized agents, 16 orchestrators, 146 skills, 79 tools in 72 focused plugins |
 | [oh-my-claudecode](https://github.com/Yeachan-Heo/oh-my-claudecode) | 9,900+ | Teams-first multi-agent orchestration with 19 specialized agents and 28 skills |

--- a/README.md
+++ b/README.md
@@ -1067,7 +1067,6 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 
 | Name | Stars | Description |
 |------|-------|-------------|
-| [Concord MCP](https://github.com/Get-Concord-AI/concord-mcp) | 240+ | Cross-harness coordination for Claude Code, Codex, Cursor, Gemini CLI, and Grok Build. Agents claim work, detect edit overlap, exchange durable messages, transfer ownership, and hand off review evidence through five MCP workflow tools. MIT, npm: `@concord-ai/concord-mcp` |
 | [claude-mem](https://github.com/thedotmack/claude-mem) | 35,900+ | Auto-captures everything Claude does, compresses with AI, injects context into future sessions. #1 trending GitHub Feb 2026 |
 | [wshobson/agents](https://github.com/wshobson/agents) | 31,300+ | 112 specialized agents, 16 orchestrators, 146 skills, 79 tools in 72 focused plugins |
 | [oh-my-claudecode](https://github.com/Yeachan-Heo/oh-my-claudecode) | 9,900+ | Teams-first multi-agent orchestration with 19 specialized agents and 28 skills |
@@ -1088,6 +1087,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [myclaude](https://github.com/stellarlinkco/myclaude) | 2,400+ | Multi-agent orchestration routing to Claude Code, Codex, Gemini, and OpenCode |
 | [claude-code-mcp](https://github.com/steipete/claude-code-mcp) | 1,100+ | Run Claude Code as a one-shot MCP server -- an agent in your agent |
 | [ccmanager](https://github.com/kbwo/ccmanager) | 940+ | Session manager supporting 8 coding agents with smart auto-approval |
+| [Concord MCP](https://github.com/Get-Concord-AI/concord-mcp) | 243 | Cross-harness messaging and shared task state for Claude Code, Codex, Cursor, Gemini CLI, and Grok Build via MCP. MIT |
 | [cog](https://github.com/marciopuga/cog) | 240+ | Cognitive architecture for Claude Code -- persistent memory, self-reflection, and foresight via plain-text conventions. Zero dependencies, just CLAUDE.md + markdown files |
 | [claude-memory-bridge](https://github.com/LewenW/claude-memory-bridge) | -- | Cross-project memory sharing via namespaces. Adds a shared layer between global and project-scoped memory so projects selectively share knowledge. MCP server, no database |
 | [Cortex](https://github.com/SKULLFIRE07/cortex-memory) | -- | Persistent AI memory for coding assistants. Auto-captures decisions, patterns, and context across sessions. VSCode extension + CLI + MCP server. Free |

--- a/README.md
+++ b/README.md
@@ -1087,7 +1087,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [myclaude](https://github.com/stellarlinkco/myclaude) | 2,400+ | Multi-agent orchestration routing to Claude Code, Codex, Gemini, and OpenCode |
 | [claude-code-mcp](https://github.com/steipete/claude-code-mcp) | 1,100+ | Run Claude Code as a one-shot MCP server -- an agent in your agent |
 | [ccmanager](https://github.com/kbwo/ccmanager) | 940+ | Session manager supporting 8 coding agents with smart auto-approval |
-| [Concord MCP](https://github.com/Get-Concord-AI/concord-mcp) | 243 | Cross-harness messaging and shared task state for Claude Code, Codex, Cursor, Gemini CLI, and Grok Build via MCP. MIT |
+| [Concord MCP](https://github.com/Get-Concord-AI/concord-mcp) | 243 | Cross-harness messaging and shared task state for Claude Code, Codex, Cursor, Gemini CLI, and Grok Build via MCP. npm: `@concord-ai/concord-mcp`. MIT |
 | [cog](https://github.com/marciopuga/cog) | 240+ | Cognitive architecture for Claude Code -- persistent memory, self-reflection, and foresight via plain-text conventions. Zero dependencies, just CLAUDE.md + markdown files |
 | [claude-memory-bridge](https://github.com/LewenW/claude-memory-bridge) | -- | Cross-project memory sharing via namespaces. Adds a shared layer between global and project-scoped memory so projects selectively share knowledge. MCP server, no database |
 | [Cortex](https://github.com/SKULLFIRE07/cortex-memory) | -- | Persistent AI memory for coding assistants. Auto-captures decisions, patterns, and context across sessions. VSCode extension + CLI + MCP server. Free |


### PR DESCRIPTION
Adds Concord MCP to the ecosystem table. Concord lets Claude Code coordinate with Codex, Cursor, Gemini CLI, and Grok Build through explicit work claims, edit-overlap detection, durable messages, ownership transfer, and evidence-bearing handoffs.

Repository: https://github.com/Get-Concord-AI/concord-mcp
npm: `@concord-ai/concord-mcp`
License: MIT

Validation: `git diff --check`; repository URL resolves.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Concord MCP ecosystem listing to include the npm package name `@concord-ai/concord-mcp` alongside its existing MIT license information.
  * Clarified where the package can be found, making the listing more useful for readers evaluating or integrating the Concord MCP ecosystem entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->