### PR TITLE
Add Belay to Companion Apps & GUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1058,6 +1058,7 @@ claude-code-toolkit/               850+ files
 | [cctally](https://github.com/omrikais/cctally) | new | Track Claude Code subscription usage as a weekly $-per-1% trend. Local web dashboard, terminal UI, forecasts, threshold alerts. Apache-2.0, zero telemetry. |
 | [claude-code-notifier](https://github.com/saiso/claude-code-notifier) | new | Native macOS notifier for Claude Code. Swift + UserNotifications, custom Heroicons-derived icon (SF Symbols–free), click-through to your IDE (VS Code, Cursor, Windsurf, JetBrains, iTerm2, Terminal) via bundle ID swap, per-event sound labels, hardened inputs (allowlists, length caps, control-character stripping). Universal binary (arm64 + x86_64), macOS 12+, MIT |
 | [ToutKit](https://github.com/toutkit/toutkit) | new | Desktop notebook for AI CLIs (Claude Code, Codex, Gemini). Pairs a sidebar of notes with a built-in terminal and an in-app webview that renders whatever the AI writes — each note is a self-contained folder with its own SQLite, key/value store, attached files, and scripts, so a note can grow from a static page into a sortable table, dashboard, or research tool. Local-first, AGPL-3.0 |
+| [Belay](https://github.com/PerfectoWeb/Belay) | new | Menu bar app that keeps the Mac awake while Claude Code and other agents run, then lets it sleep when they finish. Auto-detects Claude Code, Codex, Copilot CLI, Cline. Source-available, no telemetry |
 
 ---
 


### PR DESCRIPTION
Adding Belay - a free menu bar app that keeps the Mac awake while Claude Code (and other coding agents) work, and lets it sleep when they're done. Source-available, no telemetry. Fits next to the other companion apps here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Belay, a macOS menu bar utility for preventing sleep while supported coding tools are running and allowing sleep afterward.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->