### PR TITLE
Add YYLO to Companion Apps & GUIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1058,6 +1058,7 @@ claude-code-toolkit/               850+ files
 | [cctally](https://github.com/omrikais/cctally) | new | Track Claude Code subscription usage as a weekly $-per-1% trend. Local web dashboard, terminal UI, forecasts, threshold alerts. Apache-2.0, zero telemetry. |
 | [claude-code-notifier](https://github.com/saiso/claude-code-notifier) | new | Native macOS notifier for Claude Code. Swift + UserNotifications, custom Heroicons-derived icon (SF Symbols–free), click-through to your IDE (VS Code, Cursor, Windsurf, JetBrains, iTerm2, Terminal) via bundle ID swap, per-event sound labels, hardened inputs (allowlists, length caps, control-character stripping). Universal binary (arm64 + x86_64), macOS 12+, MIT |
 | [ToutKit](https://github.com/toutkit/toutkit) | new | Desktop notebook for AI CLIs (Claude Code, Codex, Gemini). Pairs a sidebar of notes with a built-in terminal and an in-app webview that renders whatever the AI writes — each note is a self-contained folder with its own SQLite, key/value store, attached files, and scripts, so a note can grow from a static page into a sortable table, dashboard, or research tool. Local-first, AGPL-3.0 |
+| [YYLO](https://github.com/yylo-dev/yylo) | 56 | Orchestrator that runs CLI coding agents (Claude Code, Codex, Gemini CLI) on a Kanban board, each task in an isolated git worktree behind a gated merge queue. MIT, `npm i -g @yylo/cli` |
 
 ---
 


### PR DESCRIPTION
## Summary

**[YYLO](https://github.com/yylo-dev/yylo)** is a command-line orchestrator for coding agents. It runs CLI coding agents (Claude Code, Codex, Gemini CLI) on a Kanban board, with each task executing in an isolated git worktree behind a gated merge queue (preflight checks, review queue, repair loop).

### What this adds

One row at the bottom of the **Companion Apps & GUIs** table, in the shape of the existing entries (e.g. Vibe Kanban, Bernstein, Watchfire). Description follows the upstream README (npm package `@yylo/cli`, MIT).

- Repo: https://github.com/yylo-dev/yylo
- License: MIT (GitHub-detected)
- Install: `npm i -g @yylo/cli`

Disclosure: I maintain YYLO.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added YYLO to the Companion Apps & GUIs list, including an overview of its Kanban orchestration, isolated worktrees, gated merge queue, MIT license, and npm installation command.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->