### PR TITLE
Add OrcaReplay to Ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1162,7 +1162,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [voidly-mcp-server](https://github.com/voidly-ai/mcp-server) | new | 116 tools for Claude Code covering censorship intelligence (19.6M OONI measurements, 126 countries), E2E encrypted agent-to-agent messaging, and agent payments. Install: `claude mcp add voidly -- npx -y @voidly/mcp-server` |
 | [systemprompt-template](https://github.com/systempromptio/systemprompt-template) | -- | Governance infrastructure for Claude Code. Single compiled Rust binary that authenticates, authorises, rate-limits, logs, and attributes costs for every AI interaction before it reaches a tool or database. Self-hosted, air-gap capable, MCP + A2A compatible. BSL-1.1 |
 | [llm-prices](https://github.com/benbencodes/llm-prices) | new | CLI + Python library + MCP server to look up and compare LLM API costs across 167 models from 23 providers (OpenAI, Anthropic, Google, xAI, DeepSeek, Groq, and more). Ask Claude "what's the cheapest model for 10k input + 2k output?" before making API calls. Zero deps, no API key. `pipx install git+https://github.com/benbencodes/llm-prices` |
-| [OrcaReplay](https://github.com/Continuum-AI-Corp/OrcaReplay) | 150+ | Records a Claude Code run below the harness — model traffic, shell exit codes, per-turn file changes and MCP calls on one timeline — then replays it offline byte-for-byte or forks it from a checkpoint onto another model. |
+| [OrcaReplay](https://github.com/Continuum-AI-Corp/OrcaReplay) | 150+ | Records a Claude Code run below the harness — model traffic, shell exit codes, per-turn file changes and MCP calls on one timeline — then replays it offline with the network off, or forks it from a checkpoint onto another model. |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1162,6 +1162,7 @@ Notable projects, directories, and resources across the Claude Code ecosystem.
 | [voidly-mcp-server](https://github.com/voidly-ai/mcp-server) | new | 116 tools for Claude Code covering censorship intelligence (19.6M OONI measurements, 126 countries), E2E encrypted agent-to-agent messaging, and agent payments. Install: `claude mcp add voidly -- npx -y @voidly/mcp-server` |
 | [systemprompt-template](https://github.com/systempromptio/systemprompt-template) | -- | Governance infrastructure for Claude Code. Single compiled Rust binary that authenticates, authorises, rate-limits, logs, and attributes costs for every AI interaction before it reaches a tool or database. Self-hosted, air-gap capable, MCP + A2A compatible. BSL-1.1 |
 | [llm-prices](https://github.com/benbencodes/llm-prices) | new | CLI + Python library + MCP server to look up and compare LLM API costs across 167 models from 23 providers (OpenAI, Anthropic, Google, xAI, DeepSeek, Groq, and more). Ask Claude "what's the cheapest model for 10k input + 2k output?" before making API calls. Zero deps, no API key. `pipx install git+https://github.com/benbencodes/llm-prices` |
+| [OrcaReplay](https://github.com/Continuum-AI-Corp/OrcaReplay) | 150+ | Records a Claude Code run below the harness — model traffic, shell exit codes, per-turn file changes and MCP calls on one timeline — then replays it offline byte-for-byte or forks it from a checkpoint onto another model. |
 
 ---
 


### PR DESCRIPTION
Adds OrcaReplay to the **Ecosystem** table.

`claude-mem`, already at the top of that table, auto-captures what Claude does and feeds it back as context. OrcaReplay captures a level lower and for a different purpose: at the process and socket boundary, so the model traffic, the shell commands with their exit codes, the per-turn file changes and the MCP calls all sit on one timeline — and then it can **rerun** the session rather than summarise it. Replay serves the recorded responses back with the network off, reproducing the run byte-for-byte on another machine; fork restarts from a chosen checkpoint against a different model.

Row matches the table's three columns (Name / Stars / Description). Stars listed as 150+ — the repository is nine days old, so it will look small next to its neighbours there; saying so up front rather than rounding it up.

Apache-2.0, `npm i -g orcareplay`, Node 20+. Claude Code is the primary validated target, with a write-up of a real bug fix recorded, replayed offline end to end and forked.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added OrcaReplay to the ecosystem listing, highlighting its ability to record and replay Claude Code runs offline or fork them from checkpoints onto another model.
  - Clarified that offline replay operates with the network disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->